### PR TITLE
Add Talos Linux cluster support and multi-env tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,14 @@ The repository supports three environments:
 - Domain: `stage.levangie.dev`
 - Production-like testing environment
 
+### Talos Test (experimental)
+- Cluster nodes: 172.20.20.131-133
+- Distribution: **Talos Linux** + upstream Kubernetes (not K3s, not Debian)
+- Managed via `terraform/talos_cluster_test/` (uses the `siderolabs/talos` provider for bootstrap) and `scripts/helpers/import-talos-template.sh` for the Proxmox template
+- VMs have `onboot = false` and do not start on Proxmox host boot
+- No Ansible: Talos has no SSH/package manager; the existing `k3s` role does not apply here
+- App deployment (kubectl/helm, ArgoCD) still works against the cluster API if/when wired up; not yet integrated with `scripts/deploy-k3s-apps.sh` or `scripts/helpers/k3s-context-manager.sh`
+
 ## Application Configuration
 
 Applications are configured using a two-layer approach:

--- a/ansible/group_vars/talos_cluster_test.yml
+++ b/ansible/group_vars/talos_cluster_test.yml
@@ -1,0 +1,34 @@
+---
+# Talos test cluster bootstrap settings. Shared platform defaults still come
+# from group_vars/k3s_cluster.yml; this file overrides only Talos-specific
+# environment identity and network/runtime details.
+
+cluster_environment: "talos-test"
+cluster_dns_name: "talos-test.{{ cluster_tld }}"
+
+platform_primary_node_ip: "172.20.20.131"
+platform_master_nodes:
+  - "talos-test-node-1"
+platform_cluster_nodes:
+  - "talos-test-node-1"
+  - "talos-test-node-2"
+  - "talos-test-node-3"
+platform_cluster_node_count: 3
+
+metallb_ip_range: "172.20.20.241-172.20.20.250"
+traefik_loadbalancer_ip: "172.20.20.241"
+
+# Match the current test environment's backup posture until Talos has been
+# exercised long enough to trust as a backup source.
+enable_longhorn_backup: false
+longhorn_default_data_path: "/var/mnt/longhorn"
+longhorn_namespace_pod_security_enforce: "privileged"
+longhorn_namespace_pod_security_audit: "privileged"
+longhorn_namespace_pod_security_warn: "privileged"
+metallb_namespace_pod_security_enforce: "privileged"
+metallb_namespace_pod_security_audit: "privileged"
+metallb_namespace_pod_security_warn: "privileged"
+
+# Root apps for Talos test are intentionally minimal in the first pass.
+enabled_apps: []
+force_redeploy_apps: []

--- a/ansible/playbooks/k8s-bootstrap-cluster.yml
+++ b/ansible/playbooks/k8s-bootstrap-cluster.yml
@@ -1,0 +1,32 @@
+---
+- name: Bootstrap Kubernetes platform services from kubeconfig
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars_files:
+    - ../group_vars/k3s_cluster_vault.yml
+    - ../group_vars/k3s_cluster.yml
+    - "../group_vars/{{ target_cluster }}.yml"
+
+  pre_tasks:
+    - name: Assert required variables are present
+      ansible.builtin.assert:
+        that:
+          - target_cluster is defined
+          - kubeconfig_path is defined
+          - kubeconfig_path | length > 0
+        fail_msg: "target_cluster and kubeconfig_path are required"
+
+    - name: Check kubeconfig file exists
+      ansible.builtin.stat:
+        path: "{{ kubeconfig_path }}"
+      register: bootstrap_kubeconfig
+
+    - name: Fail when kubeconfig file is missing
+      ansible.builtin.fail:
+        msg: "Kubeconfig '{{ kubeconfig_path }}' does not exist"
+      when: not bootstrap_kubeconfig.stat.exists
+
+  roles:
+    - role: ../roles/k8s_platform

--- a/ansible/playbooks/maintenance/vault-unseal.yml
+++ b/ansible/playbooks/maintenance/vault-unseal.yml
@@ -1,0 +1,281 @@
+---
+# Unseal Vault, reconfigure Kubernetes auth, and recover External Secrets
+#
+# Handles the common scenario where a Vault pod restart leaves Vault sealed
+# and the Kubernetes auth JWT stale, causing all ExternalSecrets to fail.
+#
+# Works for any cluster (K3s or Talos) — runs entirely from localhost via kubectl.
+#
+# Usage:
+#   ansible-playbook ansible/playbooks/maintenance/vault-unseal.yml \
+#     -e "kubectl_context=k3s-prod"
+#
+#   ansible-playbook ansible/playbooks/maintenance/vault-unseal.yml \
+#     -e "kubectl_context=talos-test"
+#
+# What it does:
+#   1. Checks Vault seal status
+#   2. Unseals using keys from the vault-init Kubernetes secret
+#   3. Reconfigures Vault Kubernetes auth (refreshes the SA token/CA cert)
+#   4. Restarts external-secrets operator deployments
+#   5. Verifies ClusterSecretStore and all ExternalSecrets recover
+
+- name: Vault unseal and External Secrets recovery
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    vault_namespace: "vault"
+    vault_init_secret_name: "vault-init"
+    external_secrets_namespace: "external-secrets"
+    # How long to wait for ExternalSecrets to resync after recovery
+    es_recovery_retries: 12
+    es_recovery_delay: 10
+
+  pre_tasks:
+    - name: Assert kubectl_context is provided
+      ansible.builtin.assert:
+        that:
+          - kubectl_context is defined
+          - kubectl_context | length > 0
+        fail_msg: "kubectl_context is required (e.g. k3s-prod, talos-test)"
+
+  tasks:
+    # ── Discover Vault pod ────────────────────────────────────────────
+    - name: Find Vault pod
+      shell: >
+        kubectl --context {{ kubectl_context }} get pod
+        -l app.kubernetes.io/name=vault -n {{ vault_namespace }}
+        -o jsonpath='{.items[0].metadata.name}'
+      register: vault_pod_check
+      failed_when: false
+      changed_when: false
+
+    - name: Abort if Vault is not deployed
+      ansible.builtin.fail:
+        msg: "No Vault pod found in namespace '{{ vault_namespace }}' on context '{{ kubectl_context }}'"
+      when: vault_pod_check.rc != 0 or vault_pod_check.stdout | length == 0
+
+    - name: Set Vault pod name
+      set_fact:
+        vault_pod: "{{ vault_pod_check.stdout }}"
+
+    - name: Wait for Vault pod to be Running
+      shell: >
+        kubectl --context {{ kubectl_context }} get pod {{ vault_pod }}
+        -n {{ vault_namespace }} -o jsonpath='{.status.phase}'
+      register: vault_phase
+      retries: 30
+      delay: 10
+      until: vault_phase.stdout == "Running"
+      changed_when: false
+
+    # ── Check seal status ─────────────────────────────────────────────
+    - name: Get Vault status
+      shell: >
+        kubectl --context {{ kubectl_context }} exec -n {{ vault_namespace }}
+        {{ vault_pod }} -- vault status -format=json
+      register: vault_status_raw
+      failed_when: false
+      changed_when: false
+
+    - name: Parse Vault status
+      set_fact:
+        vault_initialized: "{{ (vault_status_raw.stdout | from_json).initialized | default(false) }}"
+        vault_sealed: "{{ (vault_status_raw.stdout | from_json).sealed | default(true) }}"
+      when: vault_status_raw.stdout | default('') | length > 0
+
+    - name: Abort if Vault is not initialized
+      ansible.builtin.fail:
+        msg: "Vault is not initialized. Run the bootstrap playbook first."
+      when: not (vault_initialized | default(false))
+
+    - name: Report Vault already unsealed
+      debug:
+        msg: "Vault is already unsealed — skipping unseal, proceeding to auth refresh."
+      when: not (vault_sealed | default(true))
+
+    # ── Unseal Vault ──────────────────────────────────────────────────
+    - name: Read vault-init secret
+      shell: >
+        kubectl --context {{ kubectl_context }} get secret {{ vault_init_secret_name }}
+        -n {{ vault_namespace }} -o json
+      register: vault_init_secret_raw
+      when: vault_sealed | default(true)
+      no_log: true
+
+    - name: Parse unseal keys and root token
+      set_fact:
+        vault_unseal_keys:
+          - "{{ (vault_init_secret_raw.stdout | from_json).data['unseal-key-1'] | b64decode }}"
+          - "{{ (vault_init_secret_raw.stdout | from_json).data['unseal-key-2'] | b64decode }}"
+          - "{{ (vault_init_secret_raw.stdout | from_json).data['unseal-key-3'] | b64decode }}"
+        vault_root_token: "{{ (vault_init_secret_raw.stdout | from_json).data['root-token'] | b64decode }}"
+      when: vault_sealed | default(true)
+      no_log: true
+
+    - name: Unseal Vault
+      shell: >
+        kubectl --context {{ kubectl_context }} exec -n {{ vault_namespace }}
+        {{ vault_pod }} -- vault operator unseal '{{ item }}'
+      loop: "{{ vault_unseal_keys }}"
+      when:
+        - vault_sealed | default(true)
+        - vault_unseal_keys is defined
+      no_log: true
+
+    - name: Verify Vault is unsealed
+      shell: >
+        kubectl --context {{ kubectl_context }} exec -n {{ vault_namespace }}
+        {{ vault_pod }} -- vault status -format=json
+      register: vault_post_unseal
+      retries: 5
+      delay: 5
+      until: vault_post_unseal.rc == 0 and not (vault_post_unseal.stdout | from_json).sealed
+      changed_when: false
+      when: vault_sealed | default(true)
+
+    - name: Vault unsealed
+      debug:
+        msg: "Vault has been unsealed successfully."
+      when: vault_sealed | default(true)
+
+    # ── Read root token (if we didn't unseal, we still need it) ───────
+    - name: Read root token from secret
+      shell: >
+        kubectl --context {{ kubectl_context }} get secret {{ vault_init_secret_name }}
+        -n {{ vault_namespace }} -o jsonpath='{.data.root-token}'
+      register: vault_root_token_raw
+      when: vault_root_token is not defined
+      no_log: true
+
+    - name: Set root token
+      set_fact:
+        vault_root_token: "{{ vault_root_token_raw.stdout | b64decode }}"
+      when: vault_root_token is not defined
+      no_log: true
+
+    # ── Reconfigure Kubernetes auth ───────────────────────────────────
+    # After a pod restart, Vault's internal SA token for token review
+    # may be stale. Re-writing the config forces Vault to pick up the
+    # fresh token from its mounted service account.
+    - name: Login to Vault
+      shell: >
+        kubectl --context {{ kubectl_context }} exec -n {{ vault_namespace }}
+        {{ vault_pod }} -- vault login '{{ vault_root_token }}'
+      changed_when: false
+      no_log: true
+
+    - name: Reconfigure Kubernetes auth backend
+      shell: >
+        kubectl --context {{ kubectl_context }} exec -n {{ vault_namespace }}
+        {{ vault_pod }} -- sh -c '
+          vault write auth/kubernetes/config
+            kubernetes_host="https://kubernetes.default.svc:443"
+            disable_iss_validation=true
+            disable_local_ca_jwt=false'
+      register: vault_k8s_auth_config
+      changed_when: vault_k8s_auth_config.rc == 0
+
+    - name: Kubernetes auth reconfigured
+      debug:
+        msg: "Vault Kubernetes auth backend has been refreshed with current SA token."
+
+    # ── Restart External Secrets operator ─────────────────────────────
+    - name: Check if external-secrets namespace exists
+      shell: >
+        kubectl --context {{ kubectl_context }} get namespace {{ external_secrets_namespace }}
+      register: es_ns_check
+      failed_when: false
+      changed_when: false
+
+    - name: Get external-secrets deployments
+      shell: >
+        kubectl --context {{ kubectl_context }} get deployments
+        -n {{ external_secrets_namespace }}
+        -o jsonpath='{.items[*].metadata.name}'
+      register: es_deployments
+      when: es_ns_check.rc == 0
+      changed_when: false
+
+    - name: Restart external-secrets deployments
+      shell: >
+        kubectl --context {{ kubectl_context }} rollout restart
+        deployment {{ item }} -n {{ external_secrets_namespace }}
+      loop: "{{ es_deployments.stdout.split() }}"
+      when:
+        - es_ns_check.rc == 0
+        - es_deployments.stdout | length > 0
+
+    - name: Wait for external-secrets rollouts
+      shell: >
+        kubectl --context {{ kubectl_context }} rollout status
+        deployment {{ item }} -n {{ external_secrets_namespace }} --timeout=120s
+      loop: "{{ es_deployments.stdout.split() }}"
+      when:
+        - es_ns_check.rc == 0
+        - es_deployments.stdout | length > 0
+      changed_when: false
+
+    # ── Force ClusterSecretStore resync ───────────────────────────────
+    - name: Get ClusterSecretStore names
+      shell: >
+        kubectl --context {{ kubectl_context }} get clustersecretstores
+        -o jsonpath='{.items[*].metadata.name}'
+      register: css_names
+      failed_when: false
+      changed_when: false
+      when: es_ns_check.rc == 0
+
+    - name: Annotate ClusterSecretStores to force resync
+      shell: >
+        kubectl --context {{ kubectl_context }} annotate clustersecretstore {{ item }}
+        force-sync="{{ lookup('pipe', 'date +%s') }}" --overwrite
+      loop: "{{ css_names.stdout.split() }}"
+      when:
+        - es_ns_check.rc == 0
+        - css_names.stdout | default('') | length > 0
+
+    # ── Verify recovery ──────────────────────────────────────────────
+    - name: Wait for ClusterSecretStores to become Ready
+      shell: >
+        kubectl --context {{ kubectl_context }} get clustersecretstores
+        -o jsonpath='{range .items[*]}{.metadata.name}={.status.conditions[0].reason}{" "}{end}'
+      register: css_status
+      retries: "{{ es_recovery_retries }}"
+      delay: "{{ es_recovery_delay }}"
+      until: "'InvalidProviderConfig' not in css_status.stdout and 'Valid' in css_status.stdout"
+      changed_when: false
+      when:
+        - es_ns_check.rc == 0
+        - css_names.stdout | default('') | length > 0
+
+    - name: Check ExternalSecrets sync status
+      shell: >
+        kubectl --context {{ kubectl_context }} get externalsecrets -A
+        -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.status.conditions[0].reason}{" "}{end}'
+      register: es_status
+      retries: "{{ es_recovery_retries }}"
+      delay: "{{ es_recovery_delay }}"
+      until: "'SecretSyncedError' not in es_status.stdout"
+      changed_when: false
+      failed_when: false
+      when: es_ns_check.rc == 0
+
+    - name: Display final status
+      shell: |
+        echo "=== Vault Status ==="
+        kubectl --context {{ kubectl_context }} exec -n {{ vault_namespace }} {{ vault_pod }} -- vault status 2>&1 || true
+        echo ""
+        echo "=== ClusterSecretStores ==="
+        kubectl --context {{ kubectl_context }} get clustersecretstores 2>&1 || echo "  (none)"
+        echo ""
+        echo "=== ExternalSecrets ==="
+        kubectl --context {{ kubectl_context }} get externalsecrets -A 2>&1 || echo "  (none)"
+      register: final_status
+      changed_when: false
+
+    - name: Recovery summary
+      debug:
+        msg: "{{ final_status.stdout_lines }}"

--- a/ansible/roles/k3s/tasks/longhorn.yml
+++ b/ansible/roles/k3s/tasks/longhorn.yml
@@ -690,7 +690,7 @@
 - name: Create DNS CNAME record for Longhorn UI
   include_tasks: shared/dns_management.yml
   vars:
-    dns_record_name: "{{ environment_prefix }}longhorn"
+    dns_record_name: "{{ ('longhorn.' + environment_domain) | regex_replace('\\.' + cluster_tld + '$', '') }}"
     dns_record_type: "CNAME"
     dns_record_target: "{{ cluster_dns_name }}"
     dns_record_action: "create"

--- a/ansible/roles/k8s_platform/defaults/main.yml
+++ b/ansible/roles/k8s_platform/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+kubeconfig_path: ""
+platform_primary_node_ip: ""
+platform_master_nodes: []
+platform_cluster_nodes: []
+platform_cluster_node_count: 0
+
+platform_install_longhorn: true
+platform_install_metallb: true
+platform_install_traefik: true
+platform_install_argocd: true
+platform_configure_vault: true
+
+longhorn_default_data_path: "/var/lib/longhorn"
+
+longhorn_namespace_pod_security_enforce: ""
+longhorn_namespace_pod_security_audit: ""
+longhorn_namespace_pod_security_warn: ""
+
+metallb_namespace_pod_security_enforce: ""
+metallb_namespace_pod_security_audit: ""
+metallb_namespace_pod_security_warn: ""

--- a/ansible/roles/k8s_platform/tasks/argocd.yml
+++ b/ansible/roles/k8s_platform/tasks/argocd.yml
@@ -1,0 +1,330 @@
+---
+# ArgoCD Installation
+# GitOps continuous delivery tool for Kubernetes
+
+- name: Check ArgoCD service health
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} get svc argocd-server -n argocd -o jsonpath='{.spec.clusterIP}' 2>/dev/null
+  register: argocd_service_check
+  failed_when: false
+  changed_when: false
+
+- name: Check if ArgoCD pods are running
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} get pods -n argocd -l app.kubernetes.io/name=argocd-server -o jsonpath='{.items[0].status.phase}' 2>/dev/null
+  register: argocd_pod_check
+  failed_when: false
+  changed_when: false
+
+- name: Check if ArgoCD Helm release exists
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    helm list -n argocd -o json | grep -q '"name":"argocd"'
+  register: argocd_helm_check
+  failed_when: false
+  changed_when: false
+
+- name: Determine if ArgoCD needs deployment
+  set_fact:
+    argocd_needs_deployment: "{{ force_argocd_redeploy | default(false) or argocd_service_check.stdout == '' or argocd_pod_check.stdout != 'Running' or argocd_helm_check.rc != 0 }}"
+
+- name: Display ArgoCD status
+  debug:
+    msg: |
+      ArgoCD Current Status:
+      Service ClusterIP: {{ argocd_service_check.stdout | default('Not found') }}
+      Pod Status: {{ argocd_pod_check.stdout | default('Not found') }}
+      Helm Release: {{ 'Found' if argocd_helm_check.rc == 0 else 'Not found' }}
+      Needs Deployment: {{ argocd_needs_deployment | default(false) }}
+      Force Redeploy: {{ force_argocd_redeploy | default(false) }}
+
+- name: Add ArgoCD Helm repository
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    helm repo add argo https://argoproj.github.io/argo-helm
+    helm repo update
+  when:
+    - argocd_needs_deployment | default(true)
+
+- name: Create ArgoCD Helm values configuration
+  template:
+    src: argocd-values.yaml.j2
+    dest: /tmp/argocd-values.yaml
+    mode: '0644'
+  when:
+    - argocd_needs_deployment | default(true)
+
+- name: Create argocd namespace
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -
+  when:
+    - argocd_needs_deployment | default(true)
+
+- name: Wait for Traefik to be ready (ArgoCD depends on ingress)
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=traefik -n traefik-system --timeout=120s
+  when:
+    - argocd_needs_deployment | default(true)
+    - platform_install_traefik | default(true)
+  ignore_errors: yes
+
+- name: Clean up any stuck Helm operations for ArgoCD
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    echo "Performing ArgoCD cleanup..."
+
+    # Uninstall Helm release
+    helm uninstall argocd -n argocd --ignore-not-found --wait=false || echo "No Helm release to uninstall"
+
+    # Force delete pods
+    kubectl delete pods -n argocd -l app.kubernetes.io/part-of=argocd --force --grace-period=0 --ignore-not-found || true
+
+    # Wait for cleanup
+    sleep 10
+
+    # Verify cleanup
+    kubectl get pods -n argocd || echo "ArgoCD namespace clean"
+  when:
+    - argocd_needs_deployment | default(true)
+    - force_argocd_redeploy | default(false)
+  ignore_errors: yes
+
+- name: Install ArgoCD using Helm
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    echo "Installing ArgoCD with Traefik ingress support..."
+    helm upgrade --install argocd argo/argo-cd \
+      --namespace argocd \
+      --values /tmp/argocd-values.yaml \
+      --wait \
+      --timeout=10m
+  register: argocd_install_result
+  retries: 2
+  delay: 60
+  when:
+    - argocd_needs_deployment | default(true)
+
+- name: Wait for ArgoCD server pods to be ready
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} wait --for=condition=ready pod \
+      -l app.kubernetes.io/name=argocd-server \
+      -n argocd \
+      --timeout=180s
+  when:
+    - argocd_needs_deployment | default(true)
+
+- name: Wait for ArgoCD Application CRD to be available
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} wait --for=condition=established crd/applications.argoproj.io --timeout=120s
+  when:
+    - argocd_needs_deployment | default(true)
+
+- name: Create ArgoCD Traefik IngressRoute
+  template:
+    src: argocd-ingress.yaml.j2
+    dest: /tmp/argocd-ingress.yaml
+    mode: '0644'
+  when:
+    - argocd_ingress_enabled | default(true)
+
+- name: Wait for Traefik CRDs before applying ArgoCD ingress
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} wait --for=condition=established crd/ingressroutes.traefik.io --timeout=120s
+  when:
+    - argocd_ingress_enabled | default(true)
+  ignore_errors: yes
+
+- name: Apply ArgoCD Traefik IngressRoute
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} apply -f /tmp/argocd-ingress.yaml
+  when:
+    - argocd_ingress_enabled | default(true)
+  retries: 3
+  delay: 10
+
+- name: Create DNS CNAME record for ArgoCD
+  include_tasks: shared/dns_management.yml
+  vars:
+    dns_record_name: "{{ 'argocd.' + environment_prefix | regex_replace('\\.$', '') if environment_prefix else 'argocd' }}"
+    dns_record_type: "CNAME"
+    dns_record_target: "{{ cluster_dns_name }}"
+    dns_record_action: "create"
+  when:
+    - argocd_ingress_enabled | default(true)
+    - manage_dns_records | default(false)
+
+- name: Create temporary file for SSH key
+  tempfile:
+    state: file
+    suffix: .key
+  register: ssh_key_tempfile
+  when:
+    - vault_argocd_ssh_private_key is defined
+  no_log: true
+
+- name: Write SSH private key to temp file
+  copy:
+    content: "{{ vault_argocd_ssh_private_key }}"
+    dest: "{{ ssh_key_tempfile.path }}"
+    mode: '0600'
+  when:
+    - vault_argocd_ssh_private_key is defined
+  no_log: true
+
+- name: Create ArgoCD repository credentials secret
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    kubectl create secret generic home-infra-repo-creds \
+      --namespace argocd \
+      --from-file=sshPrivateKey={{ ssh_key_tempfile.path }} \
+      --from-literal=type=git \
+      --from-literal=url=git@github.com:jlevangi/home-infra.git \
+      --dry-run=client -o yaml | kubectl apply -f -
+    kubectl label secret home-infra-repo-creds -n argocd \
+      argocd.argoproj.io/secret-type=repository --overwrite
+  when:
+    - vault_argocd_ssh_private_key is defined
+  no_log: true
+
+- name: Remove temporary SSH key file
+  file:
+    path: "{{ ssh_key_tempfile.path }}"
+    state: absent
+  when:
+    - vault_argocd_ssh_private_key is defined
+
+- name: Create Technitium DNS credentials for ArgoCD hooks
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    kubectl create secret generic technitium-api-credentials \
+      --namespace argocd \
+      --from-literal=server="{{ technitium_dns_server }}" \
+      --from-literal=token="{{ technitium_api_token }}" \
+      --from-literal=tld="{{ cluster_tld }}" \
+      --dry-run=client -o yaml | kubectl apply -f -
+  when:
+    - manage_dns_records | default(false)
+  no_log: true
+
+- name: Create Technitium DNS credentials in app namespaces
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    kubectl create namespace {{ item }} --dry-run=client -o yaml | kubectl apply -f -
+    kubectl create secret generic technitium-api-credentials \
+      --namespace {{ item }} \
+      --from-literal=server="{{ technitium_dns_server }}" \
+      --from-literal=token="{{ technitium_api_token }}" \
+      --from-literal=tld="{{ cluster_tld }}" \
+      --dry-run=client -o yaml | kubectl apply -f -
+  loop:
+    - factorio
+    - ittools
+    - ntfy
+    - pairdrop
+    - wallos
+    - linkding
+  when:
+    - manage_dns_records | default(false)
+  no_log: true
+
+- name: Get ArgoCD initial admin password
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} get secret argocd-initial-admin-secret -n argocd -o jsonpath='{.data.password}' | base64 -d
+  register: argocd_admin_password
+  ignore_errors: yes
+  no_log: true
+
+- name: Validate ArgoCD deployment
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    # Check if all ArgoCD components are running
+    READY_PODS=$(kubectl get pods -n argocd --no-headers | grep -c "Running" || echo "0")
+    TOTAL_PODS=$(kubectl get pods -n argocd --no-headers | wc -l)
+    if [ "$READY_PODS" -lt 5 ]; then
+      echo "WARNING: Not all ArgoCD pods are running ($READY_PODS/$TOTAL_PODS)"
+      kubectl get pods -n argocd
+    fi
+
+    echo "ArgoCD deployment status: $READY_PODS pods running"
+  register: argocd_validation
+  when:
+    - argocd_needs_deployment | default(true)
+
+- name: Deploy root ArgoCD application for environment
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    echo "Deploying root-{{ cluster_environment }} Application from {{ argocd_target_revision }} at argocd/apps/{{ cluster_environment }}..."
+    kubectl apply -f - <<'EOF'
+    apiVersion: argoproj.io/v1alpha1
+    kind: Application
+    metadata:
+      name: root-{{ cluster_environment }}
+      namespace: argocd
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+    spec:
+      project: default
+      source:
+        repoURL: git@github.com:jlevangi/home-infra.git
+        targetRevision: {{ argocd_target_revision }}
+        path: argocd/apps/{{ cluster_environment }}
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: argocd
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+    EOF
+  register: argocd_root_app_result
+  when:
+    - argocd_deploy_root_app | default(true)
+
+- name: Wait for root Application to sync
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    # Wait up to 2 minutes for the root app to sync
+    for i in $(seq 1 24); do
+      STATUS=$(kubectl get application root-{{ cluster_environment }} -n argocd -o jsonpath='{.status.sync.status}' 2>/dev/null || echo "Unknown")
+      if [ "$STATUS" = "Synced" ]; then
+        echo "Root application synced successfully"
+        exit 0
+      fi
+      echo "Waiting for root application to sync... (status: $STATUS)"
+      sleep 5
+    done
+    echo "WARNING: Root application not yet synced after 2 minutes"
+    kubectl get application root-{{ cluster_environment }} -n argocd -o yaml
+  when:
+    - argocd_deploy_root_app | default(true)
+  ignore_errors: yes
+
+- name: Display ArgoCD installation results
+  debug:
+    msg: |
+      ArgoCD Installation Complete!
+
+      Installation Status:
+      {{ argocd_install_result.stdout if argocd_install_result.stdout is defined else 'Already installed' }}
+
+      Web UI Access:
+      URL: https://argocd.{{ environment_domain }}
+      Username: admin
+      Password: Run this command to retrieve:
+        kubectl get secret argocd-initial-admin-secret -n argocd -o jsonpath='{.data.password}' | base64 -d; echo
+
+      Note: It is recommended to delete the initial admin secret after first login:
+        kubectl delete secret argocd-initial-admin-secret -n argocd
+
+      Verification Commands:
+      kubectl get pods -n argocd
+      kubectl get svc -n argocd
+      kubectl get ingressroute -n argocd
+      kubectl get applications -A
+
+      CLI Login (from cluster):
+      argocd login argocd-server.argocd.svc.cluster.local --insecure

--- a/ansible/roles/k8s_platform/tasks/longhorn.yml
+++ b/ansible/roles/k8s_platform/tasks/longhorn.yml
@@ -1,0 +1,781 @@
+---
+# Install Longhorn distributed storage system
+- name: Add Longhorn Helm repo
+  ansible.builtin.shell: helm repo add longhorn https://charts.longhorn.io
+  args:
+    creates: /tmp/longhorn-repo-added
+
+- name: Mark Longhorn repo as added
+  ansible.builtin.file:
+    path: /tmp/longhorn-repo-added
+    state: touch
+  when: not ansible_check_mode
+
+- name: Update Helm repos
+  ansible.builtin.shell: helm repo update
+
+- name: Wait for K3s API server to be fully ready
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get nodes --no-headers
+  register: api_server_check
+  until: api_server_check.rc == 0
+  retries: 60  # Increased from 30 to 60 (10 minutes total)
+  delay: 10
+
+- name: Wait for core system pods to be ready
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get pods -n kube-system --no-headers | grep -v Running | grep -v Completed | wc -l
+  register: pending_pods_check
+  until: pending_pods_check.stdout | int == 0
+  retries: 30  # 5 minutes for system pods
+  delay: 10
+
+- name: Test API server health endpoint
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get --raw /healthz
+  register: api_health_check
+  until: api_health_check.rc == 0 and api_health_check.stdout == "ok"
+  retries: 20  # Reduced to avoid long waits
+  delay: 5
+  ignore_errors: yes  # Don't fail if health check doesn't work
+
+- name: Fallback API functionality test
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get namespaces default -o name
+  register: api_fallback_check
+  until: api_fallback_check.rc == 0
+  retries: 10
+  delay: 5
+  when: api_health_check.rc != 0 or api_health_check.stdout != "ok"
+
+- name: Verify CRD API is ready (critical for Helm chart installation)
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl api-resources --api-group=apiextensions.k8s.io 2>/dev/null | grep -q customresourcedefinitions
+  register: crd_api_check
+  until: crd_api_check.rc == 0
+  retries: 30
+  delay: 10
+
+- name: Test CRD creation capability
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get crd --no-headers 2>/dev/null | head -1
+  register: crd_list_check
+  until: crd_list_check.rc == 0
+  retries: 20
+  delay: 5
+  failed_when: false
+
+- name: Display comprehensive API server status
+  debug:
+    msg: |
+      🔍 Kubernetes API Server Readiness Status:
+      ✅ Nodes accessible: {{ 'Yes' if api_server_check.rc == 0 else 'No' }}
+      ✅ System pods ready: {{ 'Yes' if pending_pods_check.stdout | int == 0 else 'No (' + pending_pods_check.stdout + ' pending)' }}
+      ✅ Health endpoint: {{ 'Healthy' if api_health_check.rc == 0 and api_health_check.stdout == 'ok' else ('Fallback OK' if api_fallback_check is defined and api_fallback_check.rc == 0 else 'Not responding') }}
+      ✅ CRD API ready: {{ 'Yes' if crd_api_check.rc == 0 else 'No - Helm install may fail' }}
+
+      🚀 Ready for Longhorn installation: {{ api_server_check.rc == 0 and pending_pods_check.stdout | int == 0 and crd_api_check.rc == 0 }}
+
+- name: Additional stability wait before Longhorn installation
+  pause:
+    seconds: 60
+    prompt: "Waiting 60 seconds for API server and CRD subsystem to fully stabilize before Longhorn installation..."
+  when: platform_fresh_install | default(false)
+
+- name: Ensure Longhorn namespace exists with required pod-security labels
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl apply -f - <<'EOF'
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: longhorn-system
+      labels:
+        pod-security.kubernetes.io/enforce: {{ longhorn_namespace_pod_security_enforce }}
+        pod-security.kubernetes.io/audit: {{ longhorn_namespace_pod_security_audit | default(longhorn_namespace_pod_security_enforce) }}
+        pod-security.kubernetes.io/warn: {{ longhorn_namespace_pod_security_warn | default(longhorn_namespace_pod_security_enforce) }}
+    EOF
+  when: longhorn_namespace_pod_security_enforce is defined
+
+- name: Check if Longhorn namespace exists
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get namespace longhorn-system
+  register: longhorn_namespace_check
+  failed_when: false
+
+- name: Check if Longhorn pods are running
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get pods -n longhorn-system --no-headers 2>/dev/null | grep -v "0/" | wc -l
+  register: longhorn_pods_check
+  failed_when: false
+  when: longhorn_namespace_check.rc == 0
+
+- name: Check if Longhorn Helm release exists
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} helm status longhorn -n longhorn-system >/dev/null 2>&1
+  register: longhorn_helm_check
+  failed_when: false
+
+- name: Check for any pending Helm operations
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} helm list --pending -A
+  register: helm_pending_check
+  failed_when: false
+
+- name: Display Longhorn installation status
+  debug:
+    msg: |
+      🔍 Current Longhorn Status:
+      Namespace exists: {{ 'Yes' if longhorn_namespace_check.rc == 0 else 'No' }}
+      Running pods: {{ longhorn_pods_check.stdout | default('0') if longhorn_namespace_check.rc == 0 else '0' }}
+      Helm release: {{ 'Yes' if longhorn_helm_check.rc == 0 else 'No' }}
+      Pending operations: {{ 'Yes' if helm_pending_check.stdout_lines | length > 1 else 'No' }}
+      
+      Action needed: {{ 'Fresh install' if longhorn_namespace_check.rc != 0 else ('Update config' if longhorn_helm_check.rc == 0 else 'Repair installation') }}
+
+- name: Display Longhorn operation result
+  debug:
+    msg: |
+      🔧 Longhorn Operation Result:
+      {% if longhorn_install_result is defined and longhorn_install_result.changed %}
+      ✅ Fresh installation completed successfully
+      {% elif longhorn_update_result is defined and longhorn_update_result.changed %}
+      ✅ Configuration updated successfully
+      {% elif longhorn_repair_result is defined and longhorn_repair_result.changed %}
+      ✅ Installation repaired (Helm release created for existing deployment)
+      {% elif longhorn_namespace_check.rc == 0 and longhorn_helm_check.rc == 0 %}
+      ℹ️  Longhorn already properly installed - no changes needed
+      {% else %}
+      ⚠️  Longhorn operation skipped or failed
+      {% endif %}
+
+- name: Calculate dynamic replica count for Longhorn
+  set_fact:
+    calculated_replica_count: "{{ [platform_cluster_node_count | default(0) | int, 3] | min }}"
+  when: longhorn_replica_count is not defined
+
+- name: Display Longhorn replica count calculation
+  debug:
+    msg: |
+      🔧 Longhorn Replica Count Calculation:
+      Cluster nodes: {{ platform_cluster_nodes | default([]) }}
+      Cluster node count: {{ platform_cluster_node_count | default(0) | int }}
+      Configured replica count: {{ longhorn_replica_count | default(calculated_replica_count | default(3)) }}
+      Final replica count: {{ longhorn_replica_count | default(calculated_replica_count | default(3)) }}
+
+- name: Clean up any stuck Helm operations for Longhorn
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl delete secret -n longhorn-system -l name=longhorn,owner=helm --ignore-not-found=true
+  when:
+    - helm_pending_check.stdout_lines | length > 1
+  ignore_errors: yes
+
+- name: Clean up failed Longhorn Helm release if exists
+  ansible.builtin.shell: |
+    # Check for failed release and uninstall it
+    if KUBECONFIG={{ kubeconfig_path }} helm status longhorn -n longhorn-system 2>/dev/null | grep -q "STATUS: failed"; then
+      echo "Found failed Longhorn release, uninstalling..."
+      KUBECONFIG={{ kubeconfig_path }} helm uninstall longhorn -n longhorn-system --wait
+      # Clean up any leftover CRDs that might block reinstall
+      KUBECONFIG={{ kubeconfig_path }} kubectl delete crd -l app.kubernetes.io/name=longhorn --ignore-not-found=true
+      sleep 30
+    fi
+  when:
+    - longhorn_namespace_check.rc != 0 or (longhorn_pods_check.stdout | default('0') | int) == 0
+    - longhorn_helm_check.rc != 0
+  ignore_errors: yes
+
+- name: Final CRD API readiness check before Helm install
+  shell: |
+    for i in $(seq 1 10); do
+      if KUBECONFIG={{ kubeconfig_path }} kubectl get crd --request-timeout=10s >/dev/null 2>&1; then
+        echo "CRD API ready"
+        exit 0
+      fi
+      echo "Waiting for CRD API... attempt $i"
+      sleep 10
+    done
+    echo "CRD API check failed after 10 attempts"
+    exit 1
+  args:
+    executable: /bin/bash
+  when:
+    - longhorn_namespace_check.rc != 0 or (longhorn_pods_check.stdout | default('0') | int) == 0
+    - longhorn_helm_check.rc != 0
+
+- name: Install Longhorn (fresh installation only)
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install longhorn longhorn/longhorn \
+      --namespace longhorn-system \
+      --create-namespace \
+      --set-string global.tolerations[0].key=CriticalAddonsOnly \
+      --set-string global.tolerations[0].operator=Equal \
+      --set-string global.tolerations[0].value=true \
+      --set-string global.tolerations[0].effect=NoExecute \
+      --set-string defaultSettings.taintToleration='CriticalAddonsOnly=true:NoExecute' \
+      --set defaultSettings.defaultReplicaCount={{ longhorn_replica_count | default(calculated_replica_count | default(3)) }} \
+      --set defaultSettings.storageReservedPercentageForDefaultDisk={{ longhorn_storage_reserved_percentage_for_default_disk | default(5) }} \
+      --set defaultSettings.defaultDataPath="{{ longhorn_default_data_path | regex_replace('/$','') }}/" \
+      {% if enable_longhorn_backup | default(true) and nfs_server_ip is defined %}--set-string defaultSettings.backupTarget="nfs://{{ nfs_server_ip }}:{{ nfs_share_backup }}{% if longhorn_backup_shared_across_clusters | default(false) %}/shared{% else %}/{{ cluster_environment | default('prod') }}{% endif %}" \
+      {% endif %}--wait --timeout=1200s
+  when:
+    - longhorn_namespace_check.rc != 0 or (longhorn_pods_check.stdout | default('0') | int) == 0
+    - longhorn_helm_check.rc != 0
+  register: longhorn_install_result
+  retries: 3
+  delay: 60
+  until: longhorn_install_result.rc == 0
+
+- name: Update Longhorn configuration (existing installation)
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade longhorn longhorn/longhorn \
+      --namespace longhorn-system \
+      --set-string global.tolerations[0].key=CriticalAddonsOnly \
+      --set-string global.tolerations[0].operator=Equal \
+      --set-string global.tolerations[0].value=true \
+      --set-string global.tolerations[0].effect=NoExecute \
+      --set-string defaultSettings.taintToleration='CriticalAddonsOnly=true:NoExecute' \
+      --set defaultSettings.defaultReplicaCount={{ longhorn_replica_count | default(calculated_replica_count | default(3)) }} \
+      --set defaultSettings.storageReservedPercentageForDefaultDisk={{ longhorn_storage_reserved_percentage_for_default_disk | default(5) }} \
+      --set defaultSettings.defaultDataPath="{{ longhorn_default_data_path | regex_replace('/$','') }}/" \
+      {% if enable_longhorn_backup | default(true) and nfs_server_ip is defined %}--set-string defaultSettings.backupTarget="nfs://{{ nfs_server_ip }}:{{ nfs_share_backup }}{% if longhorn_backup_shared_across_clusters | default(false) %}/shared{% else %}/{{ cluster_environment | default('prod') }}{% endif %}" \
+      {% endif %}--wait --timeout=600s
+  when: 
+    - longhorn_namespace_check.rc == 0
+    - longhorn_helm_check.rc == 0
+    - (longhorn_pods_check.stdout | default('0') | int) >= 10
+  register: longhorn_update_result
+  ignore_errors: yes
+
+- name: Repair broken Longhorn installation (missing Helm release or incomplete)
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} helm upgrade --install longhorn longhorn/longhorn \
+      --namespace longhorn-system \
+      --set-string global.tolerations[0].key=CriticalAddonsOnly \
+      --set-string global.tolerations[0].operator=Equal \
+      --set-string global.tolerations[0].value=true \
+      --set-string global.tolerations[0].effect=NoExecute \
+      --set-string defaultSettings.taintToleration='CriticalAddonsOnly=true:NoExecute' \
+      --set defaultSettings.defaultReplicaCount={{ longhorn_replica_count | default(calculated_replica_count | default(3)) }} \
+      --set defaultSettings.storageReservedPercentageForDefaultDisk={{ longhorn_storage_reserved_percentage_for_default_disk | default(5) }} \
+      --set defaultSettings.defaultDataPath="{{ longhorn_default_data_path | regex_replace('/$','') }}/" \
+      {% if enable_longhorn_backup | default(true) and nfs_server_ip is defined %}--set-string defaultSettings.backupTarget="nfs://{{ nfs_server_ip }}:{{ nfs_share_backup }}{% if longhorn_backup_shared_across_clusters | default(false) %}/shared{% else %}/{{ cluster_environment | default('prod') }}{% endif %}" \
+      {% endif %}--wait --timeout=1200s
+  when:
+    - longhorn_namespace_check.rc == 0
+    - longhorn_helm_check.rc != 0
+    - longhorn_install_result is not defined
+  register: longhorn_repair_result
+
+# Removed duplicate API readiness check - already done above before Longhorn installation
+
+- name: Verify kubeconfig exists and is readable
+  stat:
+    path: "{{ kubeconfig_path }}"
+  register: kubeconfig_check
+
+- name: Display kubeconfig status
+  debug:
+    msg: "Kubeconfig exists: {{ kubeconfig_check.stat.exists }}, readable: {{ kubeconfig_check.stat.readable | default('unknown') }}"
+
+- name: Wait for Longhorn manager pods to be created
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get pods -n longhorn-system -l app=longhorn-manager --no-headers 2>/dev/null | wc -l
+  register: longhorn_manager_pods_exist
+  changed_when: false
+  retries: 20
+  delay: 15
+  until: longhorn_manager_pods_exist.stdout | int > 0
+  when:
+    - kubeconfig_check.stat.exists
+    - longhorn_helm_check.rc == 0 or longhorn_install_result is defined or longhorn_repair_result is defined or longhorn_update_result is defined
+
+- name: Wait for Longhorn manager pods to be ready
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl -n longhorn-system wait --for=condition=Ready pod -l app=longhorn-manager --timeout=300s
+  register: longhorn_manager_wait
+  changed_when: false
+  retries: 5
+  delay: 30
+  until: longhorn_manager_wait.rc == 0
+  when: 
+    - kubeconfig_check.stat.exists
+    - longhorn_manager_pods_exist.stdout | int > 0
+
+- name: Wait for Longhorn driver deployer to be ready
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl -n longhorn-system wait --for=condition=Ready pod -l app=longhorn-driver-deployer --timeout=300s
+  register: longhorn_driver_wait
+  changed_when: false
+  ignore_errors: yes
+
+- name: Check Longhorn storage class is available
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get storageclass longhorn
+  register: longhorn_sc_check
+  until: longhorn_sc_check.rc == 0
+  retries: 10
+  delay: 30
+
+- name: Wait for API server before settings update
+  pause:
+    seconds: 3
+
+- name: Update Longhorn default settings to match cluster configuration
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl patch setting default-replica-count -n longhorn-system \
+      --type='merge' -p='{"value":"{{ longhorn_replica_count | default(calculated_replica_count | default(3)) }}"}'
+  register: setting_update_result
+  failed_when: false
+
+- name: Update Longhorn storage reservation setting to match cluster configuration
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl patch setting storage-reserved-percentage-for-default-disk -n longhorn-system \
+      --type='merge' -p='{"value":"{{ longhorn_storage_reserved_percentage_for_default_disk | default(5) }}"}'
+  register: storage_reservation_setting_update_result
+  failed_when: false
+
+- name: Update Longhorn replica auto-balance setting
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl patch setting replica-auto-balance -n longhorn-system \
+      --type='merge' -p='{"value":"{{ longhorn_replica_auto_balance | default("best-effort") }}"}'
+  register: replica_auto_balance_setting_result
+  failed_when: false
+
+- name: Display Longhorn setting update result
+  debug:
+    msg: |
+      🔧 Longhorn Default Replica Count Setting Update:
+      {% if setting_update_result.rc == 0 %}
+      ✅ Successfully updated default-replica-count to {{ longhorn_replica_count | default(calculated_replica_count | default(3)) }}
+      {% else %}
+      ⚠️  Setting update failed (may not exist yet): {{ setting_update_result.stderr | default('Unknown error') }}
+      💡 This is normal for fresh installations - settings will be applied via existing volume updates below
+      {% endif %}
+      {% if storage_reservation_setting_update_result.rc == 0 %}
+      ✅ Successfully updated storage-reserved-percentage-for-default-disk to {{ longhorn_storage_reserved_percentage_for_default_disk | default(5) }}%
+      {% else %}
+      ⚠️  Storage reservation setting update failed (may not exist yet): {{ storage_reservation_setting_update_result.stderr | default('Unknown error') }}
+      {% endif %}
+      {% if replica_auto_balance_setting_result.rc == 0 %}
+      ✅ Successfully updated replica-auto-balance to {{ longhorn_replica_auto_balance | default('best-effort') }}
+      {% else %}
+      ⚠️  Replica auto-balance setting update failed (may not exist yet): {{ replica_auto_balance_setting_result.stderr | default('Unknown error') }}
+      {% endif %}
+
+- name: Update Longhorn StorageClass ConfigMap to match replica count
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl patch configmap longhorn-storageclass -n longhorn-system \
+      --type='merge' -p='{"data":{"storageclass.yaml":"kind: StorageClass\napiVersion: storage.k8s.io/v1\nmetadata:\n  name: longhorn\n  annotations:\n    storageclass.kubernetes.io/is-default-class: \"true\"\nprovisioner: driver.longhorn.io\nallowVolumeExpansion: true\nreclaimPolicy: \"Delete\"\nvolumeBindingMode: Immediate\nparameters:\n  numberOfReplicas: \"{{ longhorn_replica_count | default(calculated_replica_count | default(3)) }}\"\n  replicaAutoBalance: \"{{ longhorn_replica_auto_balance | default('best-effort') }}\"\n  staleReplicaTimeout: \"30\"\n  fromBackup: \"\"\n  fsType: \"ext4\"\n  dataLocality: \"disabled\"\n  unmapMarkSnapChainRemoved: \"ignored\"\n  disableRevisionCounter: \"true\"\n  dataEngine: \"v1\"\n  backupTargetName: \"default\"\n"}}'
+  register: storageclass_configmap_update_result
+  failed_when: false
+
+- name: Wait for API server before StorageClass recreation
+  pause:
+    seconds: 10
+
+- name: Delete and recreate Longhorn StorageClass with correct replica count
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl delete storageclass longhorn
+    sleep 5
+    KUBECONFIG={{ kubeconfig_path }} kubectl apply -f - <<EOF
+    kind: StorageClass
+    apiVersion: storage.k8s.io/v1
+    metadata:
+      name: longhorn
+      annotations:
+        storageclass.kubernetes.io/is-default-class: "true"
+    provisioner: driver.longhorn.io
+    allowVolumeExpansion: true
+    reclaimPolicy: "Delete"
+    volumeBindingMode: Immediate
+    parameters:
+      numberOfReplicas: "{{ longhorn_replica_count | default(calculated_replica_count | default(3)) }}"
+      replicaAutoBalance: "{{ longhorn_replica_auto_balance | default('best-effort') }}"
+      staleReplicaTimeout: "30"
+      fromBackup: ""
+      fsType: "ext4"
+      dataLocality: "disabled"
+      unmapMarkSnapChainRemoved: "ignored"
+      disableRevisionCounter: "true"
+      dataEngine: "v1"
+      backupTargetName: "default"
+    EOF
+  register: storageclass_update_result
+  failed_when: false
+
+- name: Display StorageClass update result
+  debug:
+    msg: |
+      🔧 Longhorn StorageClass Update:
+      {% if storageclass_configmap_update_result.rc == 0 %}
+      ✅ Successfully updated StorageClass ConfigMap
+      {% else %}
+      ⚠️  ConfigMap update failed: {{ storageclass_configmap_update_result.stderr | default('Unknown error') }}
+      {% endif %}
+      {% if storageclass_update_result.rc == 0 %}
+      ✅ Successfully recreated StorageClass with {{ longhorn_replica_count | default(calculated_replica_count | default(3)) }} replicas
+      {% else %}
+      ⚠️  StorageClass recreation failed: {{ storageclass_update_result.stderr | default('Unknown error') }}
+      {% endif %}
+
+- name: Wait for API server before BackupTarget update
+  pause:
+    seconds: 10
+  when: 
+    - enable_longhorn_backup | default(true)
+    - nfs_server_ip is defined
+    - nfs_share_backup is defined
+
+- name: Update Longhorn BackupTarget resource with correct NFS format
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl patch backuptarget.longhorn.io default -n longhorn-system \
+      --type='merge' -p='{"spec":{"backupTargetURL":"nfs://{{ nfs_server_ip }}:{{ nfs_share_backup }}{% if longhorn_backup_shared_across_clusters | default(false) %}/shared{% else %}/{{ cluster_environment | default('prod') }}{% endif %}"}}'
+  register: backup_target_update_result
+  failed_when: false
+  when: 
+    - enable_longhorn_backup | default(true)
+    - nfs_server_ip is defined
+    - nfs_share_backup is defined
+
+- name: Display Longhorn backup target update result
+  debug:
+    msg: |
+      🔧 Longhorn BackupTarget Resource Update:
+      {% if backup_target_update_result.rc == 0 %}
+      ✅ Successfully updated BackupTarget resource to nfs://{{ nfs_server_ip }}:{{ nfs_share_backup }}
+      💡 Fixed NFS format with colon (:) after IP address for proper mounting
+      {% else %}
+      ⚠️  BackupTarget update failed: {{ backup_target_update_result.stderr | default('Unknown error') }}
+      💡 This is normal for fresh installations - backup target will be applied via helm values above
+      {% endif %}
+  when: 
+    - enable_longhorn_backup | default(true)
+    - nfs_server_ip is defined
+    - nfs_share_backup is defined
+
+- name: Wait for API server before PVC operations
+  pause:
+    seconds: 3
+
+- name: Check for any existing validation PVC
+  shell: KUBECONFIG={{ kubeconfig_path }} kubectl get pvc longhorn-validation-pvc --ignore-not-found=true
+  register: existing_pvc
+  retries: 3
+  delay: 10
+  until: existing_pvc.rc == 0
+  failed_when: false
+
+- name: Clean up any existing validation PVC
+  shell: KUBECONFIG={{ kubeconfig_path }} kubectl delete pvc longhorn-validation-pvc --ignore-not-found=true
+  when: existing_pvc.stdout != ""
+
+- name: Validate Longhorn storage with test PVC
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl apply -f - <<EOF
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: longhorn-validation-pvc
+      namespace: default
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Mi
+      storageClassName: longhorn
+    EOF
+  retries: 3
+  delay: 15
+  register: longhorn_validation_result
+
+- name: Wait for Longhorn to be fully ready before PVC test
+  shell: |
+    echo "Waiting for Longhorn manager pods..."
+    KUBECONFIG={{ kubeconfig_path }} kubectl wait --for=condition=Ready pod -l app=longhorn-manager -n longhorn-system --timeout=120s
+    echo "Waiting for CSI driver pods..."
+    KUBECONFIG={{ kubeconfig_path }} kubectl wait --for=condition=Ready pod -l app=csi-attacher -n longhorn-system --timeout=60s
+    KUBECONFIG={{ kubeconfig_path }} kubectl wait --for=condition=Ready pod -l app=csi-provisioner -n longhorn-system --timeout=60s
+    echo "Allowing additional time for API server and CSI driver to stabilize..."
+    sleep 60  # Extended time for API server and CSI to be fully ready for PVC operations
+  ignore_errors: yes
+
+- name: Wait for test PVC to be bound
+  shell: |
+    echo "Waiting for PVC to be bound (may take several minutes for first PVC)..."
+    KUBECONFIG={{ kubeconfig_path }} kubectl wait --for=jsonpath='{.status.phase}'=Bound pvc/longhorn-validation-pvc --timeout=600s
+  register: pvc_wait_result
+  ignore_errors: yes
+  retries: 3
+  delay: 45
+
+- name: Show PVC status if binding failed
+  shell: |
+    echo "=== PVC Status ==="
+    KUBECONFIG={{ kubeconfig_path }} kubectl get pvc longhorn-validation-pvc -o yaml
+    echo "=== Events ==="
+    KUBECONFIG={{ kubeconfig_path }} kubectl get events --sort-by='.lastTimestamp' | grep longhorn-validation-pvc || echo "No PVC events found"
+    echo "=== Longhorn Manager Logs ==="
+    KUBECONFIG={{ kubeconfig_path }} kubectl logs -n longhorn-system -l app=longhorn-manager --tail=20 || echo "No manager logs"
+  when: pvc_wait_result.rc != 0
+
+- name: Clean up test PVC
+  shell: KUBECONFIG={{ kubeconfig_path }} kubectl delete pvc longhorn-validation-pvc --ignore-not-found=true
+
+- name: Check if master nodes are registered with Longhorn
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get nodes.longhorn.io {{ item }} -n longhorn-system >/dev/null 2>&1
+  loop: "{{ platform_master_nodes | default([]) }}"
+  register: master_longhorn_check
+  failed_when: false  # Don't fail - we expect this to fail
+
+- name: Reconcile storage scheduling on masters that are in Longhorn
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl patch nodes.longhorn.io {{ item.item }} -n longhorn-system \
+      --type='merge' -p='{"spec":{"allowScheduling":{{ longhorn_exclude_master_from_storage | default(false) | ternary("false", "true") }}}}'
+  loop: "{{ master_longhorn_check.results | default([]) }}"
+  when:
+    - item.rc == 0  # Only patch if the node exists in Longhorn
+
+- name: Display master node storage scheduling status
+  debug:
+    msg: |
+      📊 Master Node Storage Scheduling Status:
+      Desired policy: {% if longhorn_exclude_master_from_storage | default(false) %}exclude master nodes from Longhorn storage{% else %}allow Longhorn storage on master nodes{% endif %}
+      {% for result in master_longhorn_check.results | default([]) %}
+      {% if result.rc == 0 %}
+      {% if longhorn_exclude_master_from_storage | default(false) %}
+      ⚠️  {{ result.item }}: Found in Longhorn - storage scheduling disabled
+      {% else %}
+      ✅ {{ result.item }}: Found in Longhorn - storage scheduling enabled
+      {% endif %}
+      {% else %}
+      ℹ️  {{ result.item }}: Not registered with Longhorn yet
+      {% endif %}
+      {% endfor %}
+  when:
+    - master_longhorn_check is defined
+
+- name: Check if any Longhorn volumes exist
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get volumes -n longhorn-system --no-headers 2>/dev/null | wc -l
+  register: volume_count
+  changed_when: false
+  failed_when: false
+
+- name: Check existing volumes with incorrect replica count
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get volumes -n longhorn-system -o jsonpath='{range .items[*]}{.metadata.name}:{.spec.numberOfReplicas}{"\n"}{end}' 2>/dev/null | \
+    awk -F: -v target={{ longhorn_replica_count | default(calculated_replica_count | default(3)) }} '$2 != target && NF > 0 {print $1}' || echo ""
+  register: incorrect_replica_volumes
+  changed_when: false
+  failed_when: false
+  when: volume_count.stdout | int > 0
+
+- name: Update existing volumes to correct replica count
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl patch volume {{ item }} -n longhorn-system \
+      --type='merge' -p='{"spec":{"numberOfReplicas":{{ longhorn_replica_count | default(calculated_replica_count | default(3)) }}}}'
+  loop: "{{ incorrect_replica_volumes.stdout_lines }}"
+  when: 
+    - volume_count.stdout | int > 0
+    - incorrect_replica_volumes is defined
+    - incorrect_replica_volumes.stdout_lines | length > 0
+
+- name: Check existing volumes with incorrect replica auto-balance setting
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get volumes -n longhorn-system -o jsonpath='{range .items[*]}{.metadata.name}:{.spec.replicaAutoBalance}{"\n"}{end}' 2>/dev/null | \
+    awk -F: -v target="{{ longhorn_replica_auto_balance | default('best-effort') }}" '$2 != target && NF > 0 {print $1}' || echo ""
+  register: incorrect_replica_auto_balance_volumes
+  changed_when: false
+  failed_when: false
+  when: volume_count.stdout | int > 0
+
+- name: Update existing volumes to correct replica auto-balance setting
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl patch volume {{ item }} -n longhorn-system \
+      --type='merge' -p='{"spec":{"replicaAutoBalance":"{{ longhorn_replica_auto_balance | default('best-effort') }}"}}'
+  loop: "{{ incorrect_replica_auto_balance_volumes.stdout_lines }}"
+  when:
+    - volume_count.stdout | int > 0
+    - incorrect_replica_auto_balance_volumes is defined
+    - incorrect_replica_auto_balance_volumes.stdout_lines | length > 0
+
+- name: Display replica count adjustment status
+  debug:
+    msg: |
+      📊 Longhorn Replica Count Adjustment:
+      Target replica count: {{ longhorn_replica_count | default(calculated_replica_count | default(3)) }}
+      Based on: min({{ platform_cluster_node_count | default(0) | int }} cluster nodes, 3)
+      Replica auto-balance target: {{ longhorn_replica_auto_balance | default('best-effort') }}
+
+      {% if volume_count.stdout | int == 0 %}
+      ℹ️  No existing volumes found - new volumes will use correct replica count
+      {% elif incorrect_replica_volumes is defined and incorrect_replica_volumes.stdout_lines | length > 0 %}
+      ✅ Updated {{ incorrect_replica_volumes.stdout_lines | length }} volume(s) to correct replica count:
+      {% for volume in incorrect_replica_volumes.stdout_lines %}
+      - {{ volume }}
+      {% endfor %}
+      {% else %}
+      ✅ All volumes already have correct replica count ({{ longhorn_replica_count | default(calculated_replica_count | default(3)) }})
+      {% endif %}
+      {% if volume_count.stdout | int == 0 %}
+      ℹ️  No existing volumes found - new volumes will inherit replica auto-balance from the StorageClass
+      {% elif incorrect_replica_auto_balance_volumes is defined and incorrect_replica_auto_balance_volumes.stdout_lines | length > 0 %}
+      ✅ Updated {{ incorrect_replica_auto_balance_volumes.stdout_lines | length }} volume(s) to replica auto-balance={{ longhorn_replica_auto_balance | default('best-effort') }}:
+      {% for volume in incorrect_replica_auto_balance_volumes.stdout_lines %}
+      - {{ volume }}
+      {% endfor %}
+      {% else %}
+      ✅ All volumes already have replica auto-balance={{ longhorn_replica_auto_balance | default('best-effort') }}
+      {% endif %}
+
+- name: Wait for updated volumes to become healthy
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl get volume {{ item }} -n longhorn-system -o jsonpath='{.status.robustness}' | grep -q 'healthy\|unknown'
+  loop: "{{ ((incorrect_replica_volumes.stdout_lines | default([])) + (incorrect_replica_auto_balance_volumes.stdout_lines | default([]))) | unique }}"
+  register: volume_health_check
+  until: volume_health_check.rc == 0
+  retries: 12
+  delay: 10
+  when: 
+    - volume_count.stdout | int > 0
+    - ((incorrect_replica_volumes.stdout_lines | default([])) + (incorrect_replica_auto_balance_volumes.stdout_lines | default([]))) | length > 0
+  ignore_errors: yes
+
+- name: Patch Longhorn frontend service to NodePort
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl patch svc longhorn-frontend -n longhorn-system \
+      -p '{"spec":{"type":"NodePort","ports":[{"port":80,"nodePort":30080,"targetPort":8000}]}}'
+
+- name: Debug DNS management conditions
+  debug:
+    msg: |
+      🔍 DNS Management Debug Info:
+      - Primary node IP: {{ platform_primary_node_ip | default('UNDEFINED') }}
+      - Master nodes: {{ platform_master_nodes | default([]) }}
+      - Longhorn UI enabled: {{ longhorn_ui_ingress_enabled | default(false) }}
+      - DNS management enabled: {{ manage_dns_records | default(false) }}
+      - Environment prefix: "{{ environment_prefix | default('UNDEFINED') }}"
+      - Traefik IP: {{ traefik_loadbalancer_ip | default('UNDEFINED') }}
+
+- name: Create DNS CNAME record for Longhorn UI
+  include_tasks: shared/dns_management.yml
+  vars:
+    dns_record_name: "{{ ('longhorn.' + environment_domain) | regex_replace('\\.' + cluster_tld + '$', '') }}"
+    dns_record_type: "CNAME"
+    dns_record_target: "{{ cluster_dns_name }}"
+    dns_record_action: "create"
+  when: 
+    - longhorn_ui_ingress_enabled | default(false)
+    - manage_dns_records | default(false)
+
+- name: Deploy Longhorn UI Ingress
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl apply -f - <<EOF
+    ---
+    # Longhorn UI Ingress with SSL support
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: longhorn-frontend-ingress
+      namespace: longhorn-system
+      annotations:
+        traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+    {% if traefik_acme_enabled | default(false) %}
+        traefik.ingress.kubernetes.io/router.tls.certresolver: letsencrypt
+    {% endif %}
+    spec:
+      ingressClassName: traefik
+    {% if traefik_acme_enabled | default(false) %}
+      tls:
+      - hosts:
+        - {{ longhorn_ui_app_url | regex_replace('https?://','') }}
+        secretName: longhorn-ui-tls
+    {% endif %}
+      rules:
+      - host: {{ longhorn_ui_app_url | regex_replace('https?://','') }}
+        http:
+          paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: longhorn-frontend
+                port:
+                  number: 80
+    EOF
+  when: 
+    - longhorn_ui_ingress_enabled | default(false)
+
+- name: Delete backup recurring jobs when backups are disabled
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl delete recurringjob -n longhorn-system --all --ignore-not-found=true
+  when:
+    - not (enable_longhorn_backup | default(true))
+  register: backup_jobs_deleted
+
+- name: Display backup jobs deletion status
+  debug:
+    msg: "🗑️  Longhorn backup recurring jobs deleted (backups disabled for this environment)"
+  when:
+    - backup_jobs_deleted is defined
+    - backup_jobs_deleted.changed
+
+- name: Create backup schedule for all volumes
+  shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl apply -f - <<EOF
+    apiVersion: longhorn.io/v1beta2
+    kind: RecurringJob
+    metadata:
+      name: backup-daily
+      namespace: longhorn-system
+    spec:
+      cron: "{{ longhorn_backup_schedule_daily | default('0 2 * * *') }}"
+      task: "backup"
+      groups:
+        - default
+      retain: {{ longhorn_backup_retain_daily | default(7) }}
+      concurrency: 2
+      labels:
+        backup-type: daily
+        cluster: {{ cluster_environment | default('production') }}
+    ---
+    apiVersion: longhorn.io/v1beta2
+    kind: RecurringJob
+    metadata:
+      name: backup-weekly
+      namespace: longhorn-system
+    spec:
+      cron: "{{ longhorn_backup_schedule_weekly | default('0 3 * * 0') }}"
+      task: "backup"
+      groups:
+        - default
+      retain: {{ longhorn_backup_retain_weekly | default(4) }}
+      concurrency: 1
+      labels:
+        backup-type: weekly
+        cluster: {{ cluster_environment | default('production') }}
+    EOF
+  when: 
+    - enable_longhorn_backup | default(true)
+    - nfs_server_ip is defined
+
+- name: Display Longhorn installation info
+  debug:
+    msg: |
+      ✅ Longhorn distributed storage is ready!
+      💾 Storage Architecture: Longhorn distributed block storage
+      📊 Access Longhorn UI:
+         🌐 NodePort: http://{{ platform_primary_node_ip }}:30080
+      {% if longhorn_ui_ingress_enabled | default(false) %}   🔗 Ingress: {{ longhorn_ui_app_url }}{% endif %}
+      🔧 Default storage class: longhorn
+      ⚡ Using local node storage with {{ longhorn_replica_count | default(calculated_replica_count | default(3)) }} replicas
+      
+      {% if enable_longhorn_backup | default(true) and nfs_server_ip is defined %}🔄 Backup Configuration:
+         📂 NFS Target: nfs://{{ nfs_server_ip }}:{{ nfs_share_backup }}
+         📅 Daily: {{ longhorn_backup_schedule_daily | default('0 2 * * *') }} (retain {{ longhorn_backup_retain_daily | default(7) }})
+         📅 Weekly: {{ longhorn_backup_schedule_weekly | default('0 3 * * 0') }} (retain {{ longhorn_backup_retain_weekly | default(4) }})
+         ✅ Automatic recurring jobs created
+      {% else %}⏸️  Backups: DISABLED (this environment restores from prod backups)
+      {% endif %}

--- a/ansible/roles/k8s_platform/tasks/main.yml
+++ b/ansible/roles/k8s_platform/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: Validate k8s_platform role inputs
+  ansible.builtin.assert:
+    that:
+      - kubeconfig_path | length > 0
+    fail_msg: "kubeconfig_path must be provided to roles/k8s_platform"
+
+- name: Include Longhorn storage installation
+  include_tasks: longhorn.yml
+  tags:
+    - longhorn
+    - storage
+    - infrastructure
+  when:
+    - platform_install_longhorn | default(true)
+
+- name: Include MetalLB installation
+  include_tasks: metallb.yml
+  tags:
+    - metallb
+    - loadbalancer
+    - infrastructure
+  when:
+    - platform_install_metallb | default(true)
+
+- name: Include Traefik installation
+  include_tasks: traefik.yml
+  tags:
+    - traefik
+    - ingress
+    - infrastructure
+  when:
+    - platform_install_traefik | default(true)
+
+- name: Include ArgoCD installation
+  include_tasks: argocd.yml
+  tags:
+    - argocd
+    - gitops
+    - infrastructure
+  when:
+    - platform_install_argocd | default(true)
+
+- name: Include Vault bootstrap
+  include_tasks: vault.yml
+  tags:
+    - vault
+    - secrets
+    - gitops
+  when:
+    - platform_configure_vault | default(true)

--- a/ansible/roles/k8s_platform/tasks/metallb.yml
+++ b/ansible/roles/k8s_platform/tasks/metallb.yml
@@ -1,0 +1,177 @@
+---
+# MetalLB Installation
+# This provides LoadBalancer services for K3s
+
+- name: Check if MetalLB namespace exists
+  shell: kubectl --kubeconfig={{ kubeconfig_path }} get namespace metallb-system
+  register: metallb_namespace_check
+  ignore_errors: yes
+  failed_when: false
+
+- name: Check if MetalLB is running (any installation method)
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    kubectl get deployment controller -n metallb-system --ignore-not-found
+  register: metallb_running_check
+  ignore_errors: yes
+  failed_when: false
+
+- name: Check if MetalLB Helm release exists
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    helm list -n metallb-system -o json | jq -r '.[].name' | grep -q metallb
+  register: metallb_helm_check
+  ignore_errors: yes
+  failed_when: false
+
+- name: Get MetalLB release status if it exists
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    helm status metallb -n metallb-system -o json | jq -r '.info.status'
+  register: metallb_status_check
+  ignore_errors: yes
+  failed_when: false
+  when: 
+    - metallb_helm_check.rc == 0
+
+- name: Uninstall failed MetalLB release if needed
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    helm uninstall metallb -n metallb-system
+  when: 
+    - metallb_helm_check.rc == 0
+    - metallb_status_check.stdout == "failed"
+  ignore_errors: yes
+
+- name: Display MetalLB installation info
+  debug:
+    msg: |
+      🔧 {{ 'Installing' if metallb_helm_check.rc != 0 and metallb_running_check.stdout == '' else 'Already running' if metallb_running_check.stdout != '' else 'Updating' }} MetalLB LoadBalancer
+      MetalLB provides LoadBalancer services for bare-metal Kubernetes clusters
+      Configuration: Layer 2 mode with IP range {{ metallb_ip_range | default('172.20.20.200-172.20.20.210') }}
+      Status: {{ 'Already running (non-Helm)' if metallb_running_check.stdout != '' and metallb_helm_check.rc != 0 else 'New installation' if metallb_helm_check.rc != 0 else 'Existing Helm installation found' }}
+      Current Status: {{ metallb_status_check.stdout | default('Not managed by Helm' if metallb_running_check.stdout != '' else 'Not installed') }}
+
+- name: Add MetalLB Helm repository
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    helm repo add metallb https://metallb.github.io/metallb || true
+    helm repo update
+  when: 
+    - metallb_running_check.stdout == '' or metallb_helm_check.rc == 0
+
+- name: Wait for K3s API server to be fully ready
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    kubectl get nodes --request-timeout=5s
+  retries: 12
+  delay: 10
+  register: k3s_api_ready
+  until: k3s_api_ready.rc == 0
+  when: 
+    - metallb_running_check.stdout == '' or metallb_helm_check.rc == 0
+
+- name: Ensure MetalLB namespace exists with required pod-security labels
+  ansible.builtin.shell: |
+    KUBECONFIG={{ kubeconfig_path }} kubectl apply -f - <<'EOF'
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: metallb-system
+      labels:
+        pod-security.kubernetes.io/enforce: {{ metallb_namespace_pod_security_enforce }}
+        pod-security.kubernetes.io/audit: {{ metallb_namespace_pod_security_audit | default(metallb_namespace_pod_security_enforce) }}
+        pod-security.kubernetes.io/warn: {{ metallb_namespace_pod_security_warn | default(metallb_namespace_pod_security_enforce) }}
+    EOF
+  when:
+    - metallb_namespace_pod_security_enforce | length > 0
+    - metallb_running_check.stdout == '' or metallb_helm_check.rc == 0
+
+- name: Check for any existing MetalLB releases across all namespaces
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    helm list --all-namespaces | grep metallb || echo "No MetalLB releases found"
+  register: metallb_all_releases_check
+  ignore_errors: yes
+  when: 
+    - metallb_running_check.stdout == '' or metallb_helm_check.rc == 0
+
+- name: Force cleanup any existing MetalLB releases
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    # Check all namespaces for metallb releases and remove them
+    for ns in $(kubectl get namespaces -o name | cut -d/ -f2); do
+      if helm list -n "$ns" | grep -q metallb; then
+        echo "Found MetalLB release in namespace $ns, removing..."
+        helm uninstall metallb -n "$ns" || true
+      fi
+    done
+    # Also try common locations just in case
+    helm uninstall metallb -n metallb-system 2>/dev/null || true
+    helm uninstall metallb -n default 2>/dev/null || true
+    helm uninstall metallb -n kube-system 2>/dev/null || true
+  when: 
+    - metallb_running_check.stdout == '' or metallb_helm_check.rc == 0
+  ignore_errors: yes
+
+- name: Install MetalLB using Helm
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    helm upgrade --install metallb metallb/metallb \
+      --namespace metallb-system \
+      --create-namespace \
+      --wait \
+      --timeout=10m
+  register: metallb_install_result
+  retries: 2
+  delay: 30
+  when: 
+    - metallb_running_check.stdout == '' or metallb_helm_check.rc == 0
+
+- name: Wait for MetalLB pods to be ready
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} wait --for=condition=ready pod \
+      -l app.kubernetes.io/name=metallb \
+      -n metallb-system \
+      --timeout=120s
+  when: 
+    - metallb_running_check.stdout == '' or metallb_helm_check.rc == 0
+
+- name: Check if MetalLB IP address pool exists
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} get ipaddresspool default-pool -n metallb-system
+  register: metallb_pool_check
+  ignore_errors: yes
+  failed_when: false
+
+- name: Create MetalLB IP address pool configuration
+  template:
+    src: metallb-config.yaml.j2
+    dest: /tmp/metallb-config.yaml
+    mode: '0644'
+  when: 
+    - metallb_pool_check.rc != 0
+
+- name: Apply MetalLB configuration
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} apply -f /tmp/metallb-config.yaml
+  register: metallb_config_result
+  when: 
+    - metallb_pool_check.rc != 0
+
+- name: Display MetalLB installation results
+  debug:
+    msg: |
+      🎉 MetalLB {{ 'Installation Complete!' if metallb_running_check.stdout == '' or metallb_helm_check.rc == 0 else 'Already Running!' }}
+      
+      📊 Installation Status:
+      {{ metallb_install_result.stdout if metallb_install_result.stdout is defined else 'Skipped - already running with kubectl installation' if metallb_running_check.stdout != '' and metallb_helm_check.rc != 0 else 'Already installed' }}
+      
+      🌐 IP Address Pool: {{ metallb_ip_range | default('172.20.20.200-172.20.20.210') }}
+      
+      ✅ MetalLB will {{ 'now' if metallb_running_check.stdout == '' or metallb_helm_check.rc == 0 else 'continue to' }} provide external IPs for LoadBalancer services
+      
+      📝 Verification Commands:
+      kubectl get pods -n metallb-system
+      kubectl get ipaddresspool -n metallb-system
+      kubectl get l2advertisement -n metallb-system

--- a/ansible/roles/k8s_platform/tasks/shared/dns_management.yml
+++ b/ansible/roles/k8s_platform/tasks/shared/dns_management.yml
@@ -1,0 +1,129 @@
+---
+# Shared DNS Management Tasks
+# This task file manages DNS records for applications and system services
+
+- name: Check if DNS management is enabled
+  debug:
+    msg: "DNS management is {{ 'enabled' if manage_dns_records | default(false) else 'disabled' }}"
+
+- name: Validate DNS management variables
+  assert:
+    that:
+      - technitium_dns_server is defined
+      - technitium_api_token is defined
+      - dns_record_name is defined
+      - dns_record_ip is defined or dns_record_target is defined
+    fail_msg: "Required DNS variables are missing. Ensure technitium_dns_server, technitium_api_token, dns_record_name, and either dns_record_ip or dns_record_target are defined."
+    success_msg: "DNS management variables validated successfully"
+  when: manage_dns_records | default(false)
+
+- name: Create/Update DNS A record
+  uri:
+    url: "http://{{ technitium_dns_server }}:5380/api/zones/records/add"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      token: "{{ technitium_api_token }}"
+      domain: "{{ dns_record_name }}.{{ cluster_tld }}"
+      type: "A"
+      value: "{{ dns_record_ip }}"
+      ttl: "{{ dns_record_ttl | default(3600) }}"
+      overwrite: "true"  # This will update existing records
+    status_code: [200, 201]
+    timeout: 30
+  register: dns_create_result
+  when: 
+    - manage_dns_records | default(false)
+    - dns_record_action | default('create') == 'create'
+    - dns_record_type | default('A') == 'A'
+    - dns_record_ip is defined
+  ignore_errors: yes
+
+- name: Create/Update DNS CNAME record
+  uri:
+    url: "http://{{ technitium_dns_server }}:5380/api/zones/records/add"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      token: "{{ technitium_api_token }}"
+      domain: "{{ dns_record_name }}.{{ cluster_tld }}"
+      type: "CNAME"
+      value: "{{ dns_record_target }}"
+      ttl: "{{ dns_record_ttl | default(3600) }}"
+      overwrite: "true"  # This will update existing records
+    status_code: [200, 201]
+    timeout: 30
+  register: dns_create_result
+  when: 
+    - manage_dns_records | default(false)
+    - dns_record_action | default('create') == 'create'
+    - dns_record_type | default('A') == 'CNAME'
+    - dns_record_target is defined
+  ignore_errors: yes
+
+- name: Display DNS record creation result
+  debug:
+    msg: |
+      📡 DNS Record Management:
+      Record: {{ dns_record_name }}.{{ cluster_tld }} → {{ dns_record_ip | default(dns_record_target) }}
+      Type: {{ dns_record_type | default('A') }}
+      {% if dns_create_result.skipped | default(false) %}
+      ⏭️  DNS management disabled or skipped
+      {% elif dns_create_result.failed | default(false) %}
+      ❌ Failed to create DNS record: {{ dns_create_result.msg | default('Unknown error') }}
+      {% else %}
+      ✅ DNS record created/updated successfully
+      {% endif %}
+  when: manage_dns_records | default(false)
+
+- name: Delete DNS A record
+  uri:
+    url: "http://{{ technitium_dns_server }}:5380/api/zones/records/delete"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      token: "{{ technitium_api_token }}"
+      domain: "{{ dns_record_name }}.{{ cluster_tld }}"
+      type: "A"
+    status_code: [200, 201, 404]  # 404 is OK if record doesn't exist
+    timeout: 30
+  register: dns_delete_result
+  when: 
+    - manage_dns_records | default(false)
+    - dns_record_action | default('create') == 'delete'
+    - dns_record_type | default('A') == 'A'
+  ignore_errors: yes
+
+- name: Delete DNS CNAME record
+  uri:
+    url: "http://{{ technitium_dns_server }}:5380/api/zones/records/delete"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      token: "{{ technitium_api_token }}"
+      domain: "{{ dns_record_name }}.{{ cluster_tld }}"
+      type: "CNAME"
+    status_code: [200, 201, 404]  # 404 is OK if record doesn't exist
+    timeout: 30
+  register: dns_delete_result
+  when: 
+    - manage_dns_records | default(false)
+    - dns_record_action | default('create') == 'delete'
+    - dns_record_type | default('A') == 'CNAME'
+  ignore_errors: yes
+
+- name: Display DNS record deletion result
+  debug:
+    msg: |
+      📡 DNS Record Cleanup:
+      Record: {{ dns_record_name }}.{{ cluster_tld }}
+      {% if dns_delete_result.skipped | default(false) %}
+      ⏭️  DNS cleanup disabled or skipped
+      {% elif dns_delete_result.failed | default(false) %}
+      ❌ Failed to delete DNS record: {{ dns_delete_result.msg | default('Unknown error') }}
+      {% else %}
+      ✅ DNS record deleted successfully (or didn't exist)
+      {% endif %}
+  when: 
+    - manage_dns_records | default(false)
+    - dns_record_action | default('create') == 'delete'

--- a/ansible/roles/k8s_platform/tasks/traefik.yml
+++ b/ansible/roles/k8s_platform/tasks/traefik.yml
@@ -1,0 +1,326 @@
+---
+# Traefik 2 Installation
+# This provides advanced ingress controller with SSL support
+
+- name: Check Traefik service health
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} get svc traefik -n traefik-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null
+  register: traefik_service_check
+  failed_when: false
+  changed_when: false
+
+- name: Check if Traefik pods are running
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} get pods -n traefik-system -l app.kubernetes.io/name=traefik -o jsonpath='{.items[0].status.phase}' 2>/dev/null
+  register: traefik_pod_check
+  failed_when: false
+  changed_when: false
+
+- name: Check if ACME is properly initialized (SSL certificates working)
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} exec -n traefik-system -l app.kubernetes.io/name=traefik -- ls -la /data/acme.json 2>/dev/null
+  register: acme_file_check
+  failed_when: false
+  changed_when: false
+
+- name: Determine if Traefik needs deployment
+  set_fact:
+    traefik_needs_deployment: "{{
+      force_traefik_redeploy | default(false) or
+      traefik_service_check.stdout == '' or
+      traefik_pod_check.stdout != 'Running' or
+      traefik_service_check.stdout == '<none>' or
+      (traefik_acme_enabled | default(false) and acme_file_check.rc != 0)
+    }}"
+
+- name: Display Traefik status
+  debug:
+    msg: |
+      🔍 Traefik Current Status:
+      Service LoadBalancer IP: {{ traefik_service_check.stdout | default('Not found') }}
+      Pod Status: {{ traefik_pod_check.stdout | default('Not found') }}
+      ACME File Exists: {{ 'Yes' if (acme_file_check.rc == 0) else 'No' if (traefik_acme_enabled | default(false)) else 'N/A (ACME disabled)' }}
+      SSL Certificates: {{ 'LetsEncrypt' if (acme_file_check.rc == 0) else 'Default/Self-signed' if (traefik_acme_enabled | default(false)) else 'Disabled' }}
+      Needs Deployment: {{ traefik_needs_deployment | default(false) }}
+      Force Redeploy: {{ force_traefik_redeploy | default(false) }}
+      Reason: {{ 'Force redeploy requested' if (force_traefik_redeploy | default(false)) else 'ACME not initialized - will deploy with SSL support' if (traefik_acme_enabled | default(false) and acme_file_check.rc != 0) else 'Service healthy' }}
+
+- name: Add Traefik Helm repository
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    helm repo add traefik https://traefik.github.io/charts
+    helm repo update
+  when: 
+    - traefik_needs_deployment | default(true)
+
+- name: Create Traefik configuration
+  template:
+    src: traefik-values.yaml.j2
+    dest: /tmp/traefik-values.yaml
+    mode: '0644'
+  when: 
+    - traefik_needs_deployment | default(true)
+
+- name: Create DNS secret for ACME (if enabled)
+  template:
+    src: traefik-dns-secret.yaml.j2
+    dest: /tmp/traefik-dns-secret.yaml
+    mode: '0600'
+  when: 
+    - traefik_acme_enabled | default(false)
+    - traefik_acme_dns_provider == 'cloudflare'
+    - traefik_needs_deployment | default(true)
+
+- name: Wait for MetalLB to be fully operational
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=metallb -n metallb-system --timeout=300s
+  when: 
+    - traefik_needs_deployment | default(true)
+    - platform_install_metallb | default(true)
+
+- name: Create traefik-system namespace first
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    kubectl create namespace traefik-system --dry-run=client -o yaml | kubectl apply -f -
+  when: 
+    - traefik_needs_deployment | default(true)
+
+- name: Clean up any stuck Helm operations for Traefik
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    echo "Performing complete Traefik cleanup..."
+    
+    # 1. Uninstall Helm release (force, no wait)
+    helm uninstall traefik -n traefik-system --ignore-not-found --wait=false || echo "No Helm release to uninstall"
+    
+    # 2. Delete all Traefik resources
+    kubectl delete deployment traefik -n traefik-system --ignore-not-found || true
+    kubectl delete replicaset -n traefik-system -l app.kubernetes.io/name=traefik --ignore-not-found || true
+    kubectl delete pods -n traefik-system -l app.kubernetes.io/name=traefik --force --grace-period=0 --ignore-not-found || true
+    
+    # 3. Clean up services and configs (but keep PVC - it has our data)
+    kubectl delete svc traefik -n traefik-system --ignore-not-found || true
+    kubectl delete configmap -n traefik-system -l app.kubernetes.io/name=traefik --ignore-not-found || true
+    
+    # 4. Wait for complete cleanup
+    echo "Waiting for cleanup to complete..."
+    sleep 15
+    
+    # 5. Verify cleanup
+    kubectl get pods -n traefik-system || echo "Traefik namespace clean"
+  when: 
+    - traefik_needs_deployment | default(true)
+  ignore_errors: yes
+
+- name: Apply DNS secret for ACME before Helm install (if enabled)
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    kubectl apply -f /tmp/traefik-dns-secret.yaml
+  when: 
+    - traefik_acme_enabled | default(false)
+    - traefik_acme_dns_provider == 'cloudflare'
+    - traefik_needs_deployment | default(true)
+  ignore_errors: yes
+
+- name: Install Traefik 2 using Helm
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    echo "Installing Traefik with SSL support..."
+    helm upgrade --install traefik traefik/traefik \
+      --namespace traefik-system \
+      --values /tmp/traefik-values.yaml \
+      --wait \
+      --timeout=15m
+  register: traefik_install_result
+  retries: 2
+  delay: 60
+  when: 
+    - traefik_needs_deployment | default(true)
+
+- name: Wait for Traefik pods to be ready
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} wait --for=condition=ready pod \
+      -l app.kubernetes.io/name=traefik \
+      -n traefik-system \
+      --timeout=180s
+  when: 
+    - traefik_needs_deployment | default(true)
+
+- name: Check if Traefik CRDs exist
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} get crd ingressroutes.traefik.io 2>/dev/null &&
+    kubectl --kubeconfig={{ kubeconfig_path }} get crd middlewares.traefik.io 2>/dev/null
+  register: traefik_crds_check
+  ignore_errors: yes
+  failed_when: false
+
+- name: Wait for Traefik CRDs to be available
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} wait --for=condition=established crd/ingressroutes.traefik.io --timeout=120s &&
+    kubectl --kubeconfig={{ kubeconfig_path }} wait --for=condition=established crd/middlewares.traefik.io --timeout=120s
+  when: 
+    - traefik_crds_check.rc == 0
+
+- name: Get Traefik LoadBalancer IP
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} get service traefik \
+      -n traefik-system \
+      -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || echo 'Pending'
+  register: traefik_lb_ip
+
+- name: Create cluster DNS A record
+  include_tasks: shared/dns_management.yml
+  vars:
+    dns_record_name: "{{ cluster_dns_name | regex_replace('\\.' + cluster_tld + '$', '') }}"
+    dns_record_type: "A"
+    dns_record_ip: "{{ traefik_lb_ip.stdout }}"
+    dns_record_action: "create"
+  when: 
+    - traefik_lb_ip.stdout != 'Pending'
+    - manage_dns_records | default(false)
+
+- name: Create Traefik Dashboard access (if enabled)
+  template:
+    src: traefik-dashboard.yaml.j2
+    dest: /tmp/traefik-dashboard.yaml
+    mode: '0644'
+  when: 
+    - traefik_dashboard_enabled | default(true)
+
+- name: Wait for Traefik CRDs before applying dashboard
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} wait --for=condition=established crd/ingressroutes.traefik.io --timeout=120s &&
+    kubectl --kubeconfig={{ kubeconfig_path }} wait --for=condition=established crd/middlewares.traefik.io --timeout=120s
+  when: 
+    - traefik_dashboard_enabled | default(true)
+  ignore_errors: yes
+
+- name: Apply Traefik Dashboard configuration
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} apply -f /tmp/traefik-dashboard.yaml
+  when:
+    - traefik_dashboard_enabled | default(true)
+  retries: 3
+  delay: 10
+
+- name: Create DNS CNAME record for Traefik dashboard
+  include_tasks: shared/dns_management.yml
+  vars:
+    # Build full dashboard hostname and strip cluster_tld to get record name
+    # Stage: traefik.stage.levangie.dev -> traefik.stage
+    # Prod: traefik.levangie.dev -> traefik
+    dns_record_name: "{{ ('traefik.' + environment_domain) | regex_replace('\\.' + cluster_tld + '$', '') }}"
+    dns_record_type: "CNAME"
+    dns_record_target: "{{ cluster_dns_name }}"
+    dns_record_action: "create"
+  when:
+    - traefik_dashboard_enabled | default(true)
+    - manage_dns_records | default(false)
+
+- name: Create TLSStore for wildcard certificate (if enabled)
+  template:
+    src: traefik-tlsstore.yaml.j2
+    dest: /tmp/traefik-tlsstore.yaml
+    mode: '0644'
+  when:
+    - traefik_wildcard_cert_enabled | default(false)
+
+- name: Apply TLSStore for wildcard certificate
+  shell: |
+    kubectl --kubeconfig={{ kubeconfig_path }} apply -f /tmp/traefik-tlsstore.yaml
+  when:
+    - traefik_wildcard_cert_enabled | default(false)
+  retries: 3
+  delay: 10
+
+- name: Validate Traefik deployment
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    # Check if LoadBalancer has external IP
+    EXTERNAL_IP=$(kubectl get svc traefik -n traefik-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || echo "")
+    if [ "$EXTERNAL_IP" = "" ] || [ "$EXTERNAL_IP" = "<none>" ]; then
+      echo "ERROR: Traefik LoadBalancer has no external IP assigned"
+      exit 1
+    fi
+    
+    # Check if pods are running
+    POD_STATUS=$(kubectl get pods -n traefik-system -l app.kubernetes.io/name=traefik -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+    if [ "$POD_STATUS" != "Running" ]; then
+      echo "ERROR: Traefik pod is not running (status: $POD_STATUS)"
+      exit 1
+    fi
+    
+    echo "SUCCESS: Traefik is properly deployed with external IP: $EXTERNAL_IP"
+  register: traefik_validation
+  when: 
+    - traefik_needs_deployment | default(true)
+  failed_when: traefik_validation.rc != 0
+
+- name: Wait for ACME initialization (SSL certificates)
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    # Wait for ACME file to exist and have content
+    i=0; while [ $i -lt 30 ]; do i=$((i+1))
+      if kubectl exec -n traefik-system -l app.kubernetes.io/name=traefik -- test -f /data/acme.json 2>/dev/null; then
+        SIZE=$(kubectl exec -n traefik-system -l app.kubernetes.io/name=traefik -- stat -c%s /data/acme.json 2>/dev/null || echo "0")
+        if [ "$SIZE" -gt "100" ]; then
+          echo "ACME file initialized with size: $SIZE bytes"
+          exit 0
+        fi
+      fi
+      echo "Waiting for ACME initialization... attempt $i/30"
+      sleep 10
+    done
+    echo "WARNING: ACME file not properly initialized after 5 minutes"
+    exit 1
+  register: acme_initialization
+  when: 
+    - traefik_acme_enabled | default(false)
+    - traefik_needs_deployment | default(true)
+  ignore_errors: yes
+
+- name: Test DNS resolution for ACME validation
+  shell: |
+    export KUBECONFIG={{ kubeconfig_path }}
+    # Test if Traefik can resolve external DNS
+    kubectl exec -n traefik-system -l app.kubernetes.io/name=traefik -- wget -q -O /dev/null --timeout=5 https://acme-v02.api.letsencrypt.org/directory 2>/dev/null || echo "DNS test failed - Traefik may not be able to reach ACME servers"
+  register: dns_test_result
+  when: 
+    - traefik_acme_enabled | default(false)
+    - traefik_needs_deployment | default(true)
+  ignore_errors: yes
+
+- name: Display Traefik installation results
+  debug:
+    msg: |
+      🎉 Traefik 2 Installation Complete!
+      
+      📊 Installation Status:
+      {{ traefik_install_result.stdout if traefik_install_result.stdout is defined else 'Already installed' }}
+      
+      🌐 LoadBalancer IP: {{ traefik_lb_ip.stdout }}
+      🎛️  Dashboard: {{ 'Enabled at http://' + traefik_lb_ip.stdout + '/dashboard/' if traefik_dashboard_enabled | default(true) and traefik_lb_ip.stdout != 'Pending' else 'Disabled or IP pending' }}
+      
+      ✅ Traefik is now ready to handle ingress traffic
+      {% if traefik_acme_enabled | default(false) %}
+      🔒 SSL Configuration:
+      - ACME Provider: {{ traefik_acme_dns_provider | default('cloudflare') }}
+      - DNS Policy: {{ traefik_dns_policy | default('None') }} (External DNS for ACME validation)
+      - ACME Storage: {{ 'Initialized' if acme_initialization.rc is defined and acme_initialization.rc == 0 else 'Warning - may need time to initialize' }}
+      - DNS Resolution: {{ 'Working' if dns_test_result.rc is defined and dns_test_result.rc == 0 else 'Check DNS configuration' }}
+      - Let's Encrypt certificates will be generated automatically for ingresses with: tls.certresolver: letsencrypt
+      {% endif %}
+      
+      📝 Verification Commands:
+      kubectl get pods -n traefik-system
+      kubectl get svc -n traefik-system
+      kubectl get ingressroute -n traefik-system
+      {% if traefik_acme_enabled | default(false) %}
+      kubectl exec -n traefik-system -l app.kubernetes.io/name=traefik -- ls -la /data/acme.json
+      {% endif %}
+      
+      💡 To create SSL-enabled ingresses, use:
+      annotations:
+        kubernetes.io/ingress.class: traefik
+        traefik.ingress.kubernetes.io/router.tls.certresolver: letsencrypt

--- a/ansible/roles/k8s_platform/tasks/vault.yml
+++ b/ansible/roles/k8s_platform/tasks/vault.yml
@@ -1,0 +1,406 @@
+---
+# Vault + External Secrets bootstrap
+
+- name: Vault bootstrap tasks
+  block:
+  - name: Check for Vault ArgoCD application
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} get application vault -n argocd
+    register: vault_app_check
+    failed_when: false
+    changed_when: false
+
+  - name: Set Vault bootstrap gate
+    set_fact:
+      vault_app_present: "{{ vault_app_check.rc == 0 }}"
+
+  - name: Skip Vault bootstrap when ArgoCD app is missing
+    debug:
+      msg: "Vault ArgoCD app not found yet; skipping Vault bootstrap."
+    when:
+      - not (vault_app_present | default(false))
+
+  - name: Wait for Vault namespace to exist
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} get namespace {{ vault_namespace }}
+    register: vault_ns_check
+    retries: 30
+    delay: 10
+    until: vault_ns_check.rc == 0
+    when:
+      - vault_app_present | default(false)
+
+  - name: Wait for Vault StatefulSet to exist
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} get statefulset {{ vault_statefulset_name }} -n {{ vault_namespace }}
+    register: vault_sts_check
+    retries: 30
+    delay: 10
+    until: vault_sts_check.rc == 0
+    when:
+      - vault_app_present | default(false)
+
+  - name: Wait for Vault pod to be Running
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} get pod \
+        -l app.kubernetes.io/name=vault \
+        -n {{ vault_namespace }} \
+        -o jsonpath='{.items[0].status.phase}'
+    register: vault_pod_phase_check
+    retries: 20
+    delay: 15
+    until: vault_pod_phase_check.stdout == "Running"
+    failed_when: false
+    ignore_errors: true
+    when:
+      - vault_app_present | default(false)
+
+  - name: Discover Vault pod name
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} get pod \
+        -l app.kubernetes.io/name=vault \
+        -n {{ vault_namespace }} \
+        -o jsonpath='{.items[0].metadata.name}'
+    register: vault_pod_lookup
+    failed_when: false
+    changed_when: false
+    when:
+      - vault_app_present | default(false)
+
+  - name: Set Vault pod name
+    set_fact:
+      vault_pod_name: "{{ vault_pod_lookup.stdout }}"
+    when:
+      - vault_app_present | default(false)
+      - vault_pod_lookup.stdout | length > 0
+
+  - name: Wait for Vault CLI to respond
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- sh -c 'vault status -format=json || true'
+    register: vault_status_raw
+    retries: 30
+    delay: 10
+    until: vault_status_raw.stdout | length > 0
+    failed_when: false
+    changed_when: false
+    ignore_errors: true
+    when:
+      - vault_app_present | default(false)
+      - vault_pod_name is defined
+
+  - name: Parse Vault status
+    set_fact:
+      vault_status: "{{ vault_status_raw.stdout | from_json }}"
+      vault_initialized: "{{ (vault_status_raw.stdout | from_json).initialized | default(false) }}"
+      vault_sealed: "{{ (vault_status_raw.stdout | from_json).sealed | default(true) }}"
+      vault_status_available: true
+    when:
+      - vault_app_present | default(false)
+      - vault_status_raw.stdout is defined
+      - vault_status_raw.stdout | length > 0
+
+  - name: Default Vault status flags when status is unavailable
+    set_fact:
+      vault_status_available: false
+      vault_initialized: false
+      vault_sealed: true
+    when:
+      - vault_app_present | default(false)
+      - vault_status_raw.stdout is not defined or vault_status_raw.stdout | length == 0
+
+  - name: Initialize Vault
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault operator init -format=json
+    register: vault_init_result
+    failed_when: false
+    when:
+      - vault_app_present | default(false)
+      - vault_status_available | default(false)
+      - not (vault_initialized | default(false))
+    no_log: true
+
+  - name: Parse Vault init data
+    set_fact:
+      vault_root_token: "{{ (vault_init_result.stdout | from_json).root_token }}"
+      vault_unseal_keys: "{{ (vault_init_result.stdout | from_json).unseal_keys_b64 }}"
+    when:
+      - vault_app_present | default(false)
+      - vault_init_result is defined
+      - vault_init_result.rc is defined
+      - vault_init_result.rc == 0
+      - vault_init_result.stdout | length > 0
+    no_log: true
+
+  - name: Store Vault init data in cluster secret
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} create secret generic {{ vault_init_secret_name }} \
+        --namespace {{ vault_namespace }} \
+        --from-literal=root-token='{{ vault_root_token }}' \
+        --from-literal=unseal-key-1='{{ vault_unseal_keys[0] }}' \
+        --from-literal=unseal-key-2='{{ vault_unseal_keys[1] }}' \
+        --from-literal=unseal-key-3='{{ vault_unseal_keys[2] }}' \
+        --dry-run=client -o yaml | kubectl --kubeconfig={{ kubeconfig_path }} apply -f -
+    when:
+      - vault_app_present | default(false)
+      - vault_root_token is defined
+      - vault_unseal_keys is defined
+    no_log: true
+
+  # --- Existing cluster path: read credentials from stored secret ---
+
+  - name: Check if Vault init secret exists
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} get secret {{ vault_init_secret_name }} -n {{ vault_namespace }} >/dev/null 2>&1
+    register: vault_init_secret_check
+    failed_when: false
+    changed_when: false
+    when:
+      - vault_app_present | default(false)
+      - vault_root_token is not defined
+
+  - name: Set Vault init secret existence
+    set_fact:
+      vault_init_secret_exists: "{{ vault_init_secret_check.rc == 0 }}"
+    when:
+      - vault_app_present | default(false)
+      - vault_root_token is not defined
+
+  - name: Read Vault init secret
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} get secret {{ vault_init_secret_name }} -n {{ vault_namespace }} -o json
+    register: vault_init_secret_raw
+    when:
+      - vault_app_present | default(false)
+      - vault_root_token is not defined
+      - vault_init_secret_exists | default(false)
+    no_log: true
+
+  - name: Parse Vault init secret
+    set_fact:
+      vault_root_token: "{{ (vault_init_secret_raw.stdout | from_json).data['root-token'] | b64decode }}"
+      vault_unseal_keys:
+        - "{{ (vault_init_secret_raw.stdout | from_json).data['unseal-key-1'] | b64decode }}"
+        - "{{ (vault_init_secret_raw.stdout | from_json).data['unseal-key-2'] | b64decode }}"
+        - "{{ (vault_init_secret_raw.stdout | from_json).data['unseal-key-3'] | b64decode }}"
+    when:
+      - vault_app_present | default(false)
+      - vault_root_token is not defined
+      - vault_init_secret_raw is defined
+      - vault_init_secret_raw.stdout is defined
+      - vault_init_secret_raw.stdout | length > 0
+    no_log: true
+
+  # --- Unseal and configure ---
+
+  - name: Unseal Vault
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault operator unseal '{{ item }}'
+    loop: "{{ vault_unseal_keys }}"
+    when:
+      - vault_app_present | default(false)
+      - vault_unseal_keys is defined
+      - vault_sealed | default(true)
+    no_log: true
+
+  - name: Verify Vault is unsealed
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault status -format=json
+    register: vault_post_unseal
+    retries: 5
+    delay: 5
+    until: vault_post_unseal.rc == 0
+    failed_when: false
+    changed_when: false
+    when:
+      - vault_app_present | default(false)
+      - vault_unseal_keys is defined
+
+  - name: Update sealed status after unseal
+    set_fact:
+      vault_sealed: "{{ (vault_post_unseal.stdout | from_json).sealed | default(true) }}"
+    when:
+      - vault_app_present | default(false)
+      - vault_post_unseal is defined
+      - vault_post_unseal.stdout is defined
+      - vault_post_unseal.stdout | length > 0
+
+  - name: Fail if Vault is still sealed after unseal attempt
+    fail:
+      msg: "Vault is still sealed after unseal attempt. Check unseal keys."
+    when:
+      - vault_app_present | default(false)
+      - vault_unseal_keys is defined
+      - vault_sealed | default(true)
+
+  - name: Login to Vault
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault login '{{ vault_root_token }}'
+    register: vault_login
+    changed_when: false
+    when:
+      - vault_app_present | default(false)
+      - vault_root_token is defined
+      - not (vault_sealed | default(true))
+    no_log: true
+
+  - name: Enable KV v2 secrets engine
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault secrets enable -path={{ vault_kv_path }} kv-v2
+    register: vault_kv_enable
+    failed_when: false
+    changed_when: "'already exists' not in (vault_kv_enable.stderr | default(''))"
+    when:
+      - vault_app_present | default(false)
+      - not (vault_sealed | default(true))
+
+  - name: Enable Kubernetes auth
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault auth enable kubernetes
+    register: vault_auth_enable
+    failed_when: false
+    changed_when: "'already exists' not in (vault_auth_enable.stderr | default(''))"
+    when:
+      - vault_app_present | default(false)
+      - not (vault_sealed | default(true))
+
+  - name: Configure Kubernetes auth
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- \
+        sh -c 'vault write auth/kubernetes/config \
+          token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+          kubernetes_host="https://kubernetes.default.svc:443" \
+          kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+    register: vault_auth_config
+    changed_when: "vault_auth_config.rc == 0"
+    when:
+      - vault_app_present | default(false)
+      - not (vault_sealed | default(true))
+
+  - name: Create ESO policy
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- sh -c 'cat <<"POLICY" | vault policy write {{ vault_external_secrets_policy }} -
+      path "{{ vault_kv_path }}/data/prod/*" {
+        capabilities = ["read"]
+      }
+      path "{{ vault_kv_path }}/data/stage/*" {
+        capabilities = ["read"]
+      }
+      path "{{ vault_kv_path }}/data/test/*" {
+        capabilities = ["read"]
+      }
+      path "{{ vault_kv_path }}/data/talos-test/*" {
+        capabilities = ["read"]
+      }
+      POLICY'
+    register: vault_policy_write
+    changed_when: "vault_policy_write.rc == 0"
+    when:
+      - vault_app_present | default(false)
+      - not (vault_sealed | default(true))
+
+  - name: Create ESO Kubernetes auth role
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault write auth/kubernetes/role/{{ vault_external_secrets_role }} \
+        bound_service_account_names={{ external_secrets_service_account }} \
+        bound_service_account_namespaces={{ external_secrets_namespace }} \
+        policies={{ vault_external_secrets_policy }} \
+        ttl=1h
+    register: vault_role_write
+    changed_when: "vault_role_write.rc == 0"
+    when:
+      - vault_app_present | default(false)
+      - not (vault_sealed | default(true))
+
+  - name: Seed Vaultwarden secrets
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault kv put {{ vault_kv_path }}/{{ cluster_environment }}/vaultwarden \
+        ADMIN_TOKEN='{{ vault_vaultwarden_admin_token }}' \
+        SMTP_HOST='{{ vault_smtp_host }}' \
+        SMTP_USERNAME='{{ vault_smtp_username }}' \
+        SMTP_PASSWORD='{{ vault_smtp_password }}'
+    when:
+      - vault_app_present | default(false)
+      - not (vault_sealed | default(true))
+      - vault_vaultwarden_admin_token is defined
+    no_log: true
+
+  - name: Seed Bookstack secrets
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault kv put {{ vault_kv_path }}/{{ cluster_environment }}/bookstack \
+        DB_PASS='{{ vault_bookstack_db_password }}' \
+        MYSQL_ROOT_PASSWORD='{{ vault_bookstack_mysql_root_password }}' \
+        MYSQL_PASSWORD='{{ vault_bookstack_db_password }}' \
+        APP_KEY='{{ vault_bookstack_app_key }}'
+    when:
+      - vault_app_present | default(false)
+      - not (vault_sealed | default(true))
+      - vault_bookstack_db_password is defined
+    no_log: true
+
+  - name: Seed PocketID secrets
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault kv put {{ vault_kv_path }}/{{ cluster_environment }}/pocketid \
+        encryption-key='{{ vault_pocketid_encryption_key }}'
+    when:
+      - vault_app_present | default(false)
+      - not (vault_sealed | default(true))
+      - vault_pocketid_encryption_key is defined
+    no_log: true
+
+  - name: Seed Paperless secrets
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault kv put {{ vault_kv_path }}/{{ cluster_environment }}/paperless \
+        MARIADB_ROOT_PASSWORD='{{ vault_paperless_mariadb_root_password }}' \
+        MARIADB_PASSWORD='{{ vault_paperless_mariadb_password }}' \
+        PAPERLESS_SECRET_KEY='{{ vault_paperless_secret_key }}' \
+        PAPERLESS_ADMIN_USER='{{ vault_paperless_admin_user }}' \
+        PAPERLESS_ADMIN_PASSWORD='{{ vault_paperless_admin_password }}'
+    when:
+      - vault_app_present | default(false)
+      - not (vault_sealed | default(true))
+      - vault_paperless_mariadb_password is defined
+    no_log: true
+
+  - name: Seed Microbin secrets
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault kv put {{ vault_kv_path }}/{{ cluster_environment }}/microbin \
+        MICROBIN_ADMIN_USERNAME='{{ vault_microbin_admin_username }}' \
+        MICROBIN_ADMIN_PASSWORD='{{ vault_microbin_admin_password }}'
+    when:
+      - vault_app_present | default(false)
+      - not (vault_sealed | default(true))
+      - vault_microbin_admin_password is defined
+    no_log: true
+
+  - name: Seed Monitoring secrets
+    shell: |
+      kubectl --kubeconfig={{ kubeconfig_path }} exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault kv put {{ vault_kv_path }}/{{ cluster_environment }}/monitoring \
+        admin-user='{{ vault_grafana_admin_username | default("admin") }}' \
+        admin-password='{{ vault_grafana_admin_password }}'
+    when:
+      - vault_app_present | default(false)
+      - not (vault_sealed | default(true))
+      - vault_grafana_admin_password is defined
+    no_log: true
+
+  - name: Display Vault installation results
+    debug:
+      msg: |
+        Vault Installation Complete!
+
+        Web UI Access:
+        URL: https://vault.{{ environment_domain }}
+
+        Root Token: Run this command to retrieve:
+          kubectl get secret {{ vault_init_secret_name }} -n {{ vault_namespace }} -o jsonpath='{.data.root-token}' | base64 -d; echo
+
+        Unseal Keys: Run this command to retrieve:
+          kubectl get secret {{ vault_init_secret_name }} -n {{ vault_namespace }} -o json | jq -r '.data | to_entries[] | select(.key | startswith("unseal-key")) | "\(.key): \(.value | @base64d)"'
+
+        Note: Save these credentials securely. They are stored in the '{{ vault_init_secret_name }}' secret in the '{{ vault_namespace }}' namespace.
+
+        Verification Commands:
+        kubectl get pods -n {{ vault_namespace }}
+        kubectl exec -n {{ vault_namespace }} {{ vault_pod_name }} -- vault status
+  tags:
+    - vault

--- a/ansible/roles/k8s_platform/templates/argocd-ingress.yaml.j2
+++ b/ansible/roles/k8s_platform/templates/argocd-ingress.yaml.j2
@@ -1,0 +1,57 @@
+# ArgoCD Traefik IngressRoute
+# Provides SSL termination via Traefik with Let's Encrypt certificates
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: argocd-server
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-ingress
+    app.kubernetes.io/part-of: argocd
+spec:
+  entryPoints:
+{% if traefik_tls_enabled | default(false) %}
+    - websecure
+  tls:
+    certResolver: letsencrypt
+{% else %}
+    - web
+{% endif %}
+  routes:
+    # Main ArgoCD UI route
+    - match: Host(`argocd.{{ environment_domain }}`)
+      kind: Rule
+      priority: 10
+      services:
+        - name: argocd-server
+          port: 80
+{% if argocd_grpc_ingress_enabled | default(false) %}
+---
+# ArgoCD gRPC IngressRoute (for CLI access)
+# Only needed if you want to use ArgoCD CLI from outside the cluster
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: argocd-server-grpc
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-ingress-grpc
+    app.kubernetes.io/part-of: argocd
+spec:
+  entryPoints:
+{% if traefik_tls_enabled | default(false) %}
+    - websecure
+  tls:
+    certResolver: letsencrypt
+{% else %}
+    - web
+{% endif %}
+  routes:
+    - match: Host(`argocd.{{ environment_domain }}`) && Headers(`Content-Type`, `application/grpc`)
+      kind: Rule
+      priority: 11
+      services:
+        - name: argocd-server
+          port: 80
+          scheme: h2c
+{% endif %}

--- a/ansible/roles/k8s_platform/templates/argocd-values.yaml.j2
+++ b/ansible/roles/k8s_platform/templates/argocd-values.yaml.j2
@@ -1,0 +1,147 @@
+# ArgoCD Helm Values for K3s with Traefik Ingress
+# SSL is terminated at Traefik, ArgoCD runs in insecure mode
+
+global:
+  domain: argocd.{{ environment_domain }}
+
+# Configure ArgoCD to run in insecure mode
+# CRITICAL: Required when TLS is terminated at the ingress controller (Traefik)
+configs:
+  params:
+    # Run server without TLS since Traefik handles SSL termination
+    server.insecure: true
+{% if argocd_repo_server_exec_timeout is defined %}
+    reposerver.default.timeout: {{ argocd_repo_server_exec_timeout }}
+{% endif %}
+
+  cm:
+    # Application controller settings
+    application.instanceLabelKey: argocd.argoproj.io/instance
+    exec.enabled: "true"
+    admin.enabled: "true"
+{% if argocd_resource_tracking is defined %}
+    resource.tracking.method: {{ argocd_resource_tracking }}
+{% endif %}
+
+  # RBAC configuration
+  rbac:
+    policy.default: role:readonly
+{% if argocd_admin_policy is defined %}
+    policy.csv: |
+{{ argocd_admin_policy | indent(6, true) }}
+{% endif %}
+
+# ArgoCD Server configuration
+server:
+  replicas: {{ argocd_server_replicas | default(1) }}
+  livenessProbe:
+    initialDelaySeconds: 30
+    timeoutSeconds: 5
+    periodSeconds: 10
+    failureThreshold: 6
+  readinessProbe:
+    initialDelaySeconds: 20
+    timeoutSeconds: 5
+    periodSeconds: 10
+    failureThreshold: 6
+
+  # We use Traefik IngressRoute, so disable built-in ingress
+  ingress:
+    enabled: false
+
+  # Resource limits
+  resources:
+    limits:
+      cpu: {{ argocd_server_cpu_limit | default('500m') }}
+      memory: {{ argocd_server_memory_limit | default('512Mi') }}
+    requests:
+      cpu: {{ argocd_server_cpu_request | default('100m') }}
+      memory: {{ argocd_server_memory_request | default('256Mi') }}
+
+# ArgoCD Repo Server configuration
+repoServer:
+  replicas: {{ argocd_reposerver_replicas | default(1) }}
+  livenessProbe:
+    initialDelaySeconds: 30
+    timeoutSeconds: 5
+    periodSeconds: 10
+    failureThreshold: 6
+  readinessProbe:
+    initialDelaySeconds: 20
+    timeoutSeconds: 5
+    periodSeconds: 10
+    failureThreshold: 6
+
+  resources:
+    limits:
+      cpu: {{ argocd_reposerver_cpu_limit | default('500m') }}
+      memory: {{ argocd_reposerver_memory_limit | default('512Mi') }}
+    requests:
+      cpu: {{ argocd_reposerver_cpu_request | default('100m') }}
+      memory: {{ argocd_reposerver_memory_request | default('256Mi') }}
+
+# ArgoCD Application Controller configuration
+controller:
+  replicas: {{ argocd_controller_replicas | default(1) }}
+
+  resources:
+    limits:
+      cpu: {{ argocd_controller_cpu_limit | default('1000m') }}
+      memory: {{ argocd_controller_memory_limit | default('1Gi') }}
+    requests:
+      cpu: {{ argocd_controller_cpu_request | default('250m') }}
+      memory: {{ argocd_controller_memory_request | default('512Mi') }}
+
+# Redis configuration (for caching)
+redis:
+  enabled: true
+  resources:
+    limits:
+      cpu: {{ argocd_redis_cpu_limit | default('200m') }}
+      memory: {{ argocd_redis_memory_limit | default('256Mi') }}
+    requests:
+      cpu: {{ argocd_redis_cpu_request | default('50m') }}
+      memory: {{ argocd_redis_memory_request | default('128Mi') }}
+
+# Disable Redis HA for homelab (simpler setup)
+redis-ha:
+  enabled: false
+
+# Dex (OIDC provider) - disabled by default, enable if SSO needed
+dex:
+  enabled: {{ argocd_dex_enabled | default(false) | lower }}
+{% if argocd_dex_enabled | default(false) %}
+  resources:
+    limits:
+      cpu: {{ argocd_dex_cpu_limit | default('200m') }}
+      memory: {{ argocd_dex_memory_limit | default('256Mi') }}
+    requests:
+      cpu: {{ argocd_dex_cpu_request | default('50m') }}
+      memory: {{ argocd_dex_memory_request | default('128Mi') }}
+{% endif %}
+
+# ApplicationSet Controller
+applicationSet:
+  enabled: true
+  replicas: {{ argocd_appset_replicas | default(1) }}
+
+  resources:
+    limits:
+      cpu: {{ argocd_appset_cpu_limit | default('200m') }}
+      memory: {{ argocd_appset_memory_limit | default('256Mi') }}
+    requests:
+      cpu: {{ argocd_appset_cpu_request | default('50m') }}
+      memory: {{ argocd_appset_memory_request | default('128Mi') }}
+
+# Notifications Controller
+notifications:
+  enabled: {{ argocd_notifications_enabled | default(false) | lower }}
+{% if argocd_notifications_enabled | default(false) %}
+  resources:
+    limits:
+      cpu: {{ argocd_notifications_cpu_limit | default('100m') }}
+      memory: {{ argocd_notifications_memory_limit | default('128Mi') }}
+    requests:
+      cpu: {{ argocd_notifications_cpu_request | default('50m') }}
+      memory: {{ argocd_notifications_memory_request | default('64Mi') }}
+{% endif %}

--- a/ansible/roles/k8s_platform/templates/metallb-config.yaml.j2
+++ b/ansible/roles/k8s_platform/templates/metallb-config.yaml.j2
@@ -1,0 +1,21 @@
+---
+# MetalLB IP Address Pool and L2 Advertisement Configuration
+# This configures MetalLB to provide LoadBalancer IPs in Layer 2 mode
+
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - {{ metallb_ip_range | default('172.20.20.200-172.20.20.210') }}
+---
+apiVersion: metallb.io/v1beta1 
+kind: L2Advertisement
+metadata:
+  name: default-l2advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - default-pool

--- a/ansible/roles/k8s_platform/templates/traefik-dashboard.yaml.j2
+++ b/ansible/roles/k8s_platform/templates/traefik-dashboard.yaml.j2
@@ -1,0 +1,46 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: traefik-dashboard
+  namespace: traefik-system
+  labels:
+    app.kubernetes.io/name: traefik-dashboard
+spec:
+  entryPoints:
+{% if traefik_tls_enabled | default(false) %}
+    - websecure
+  tls:
+    certResolver: letsencrypt
+{% else %}
+    - web
+{% endif %}
+  routes:
+    - match: Host(`traefik.{{ environment_domain }}`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))
+      kind: Rule
+{% if traefik_dashboard_htpasswd is defined and not traefik_dashboard_insecure | default(false) %}
+      middlewares:
+        - name: traefik-dashboard-auth
+{% endif %}
+      services:
+        - name: api@internal
+          kind: TraefikService
+{% if traefik_dashboard_htpasswd is defined %}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: traefik-dashboard-auth
+  namespace: traefik-system
+spec:
+  basicAuth:
+    secret: traefik-dashboard-auth
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: traefik-dashboard-auth
+  namespace: traefik-system
+type: Opaque
+data:
+  users: {{ traefik_dashboard_htpasswd | b64encode }}
+{% endif %}

--- a/ansible/roles/k8s_platform/templates/traefik-dns-secret.yaml.j2
+++ b/ansible/roles/k8s_platform/templates/traefik-dns-secret.yaml.j2
@@ -1,0 +1,11 @@
+{% if traefik_acme_enabled | default(false) and traefik_acme_dns_provider == 'cloudflare' %}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: traefik-dns-secret
+  namespace: traefik-system
+type: Opaque
+data:
+  email: {{ vault_cloudflare_email_address | b64encode }}
+  api-token: {{ vault_cloudflare_dns_api_key | b64encode }}
+{% endif %}

--- a/ansible/roles/k8s_platform/templates/traefik-tlsstore.yaml.j2
+++ b/ansible/roles/k8s_platform/templates/traefik-tlsstore.yaml.j2
@@ -1,0 +1,14 @@
+---
+# TLSStore for wildcard certificate configuration
+apiVersion: traefik.io/v1alpha1
+kind: TLSStore
+metadata:
+  name: default
+  namespace: traefik-system
+spec:
+  defaultGeneratedCert:
+    resolver: letsencrypt
+    domain:
+      main: "{{ traefik_wildcard_domain | default('*.' + environment_domain) }}"
+      sans:
+        - "{{ environment_domain }}"

--- a/ansible/roles/k8s_platform/templates/traefik-values.yaml.j2
+++ b/ansible/roles/k8s_platform/templates/traefik-values.yaml.j2
@@ -1,0 +1,152 @@
+# Traefik Configuration (Helm chart v35+)
+global:
+  checkNewVersion: false
+  sendAnonymousUsage: false
+
+deployment:
+  replicas: 1
+{% if traefik_acme_enabled | default(false) %}
+  initContainers:
+    - name: acme-init
+      image: busybox:1.35
+      command:
+        - sh
+        - -c
+        - |
+          touch /data/acme.json
+          chmod 600 /data/acme.json
+          ls -la /data/acme.json
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+      volumeMounts:
+        - name: traefik-certs
+          mountPath: /data
+  dnsPolicy: "{{ traefik_dns_policy | default('None') }}"
+  dnsConfig:
+    nameservers:
+{% for nameserver in traefik_external_nameservers | default(['1.1.1.1', '8.8.8.8']) %}
+      - "{{ nameserver }}"
+{% endfor %}
+    options:
+      - name: ndots
+        value: "{{ traefik_dns_ndots | default('2') }}"
+{% endif %}
+
+service:
+  enabled: true
+  type: LoadBalancer
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: "{{ traefik_loadbalancer_ip }}"
+
+ports:
+  web:
+    port: 80
+    expose:
+      default: true
+    exposedPort: 80
+  websecure:
+    port: 8443
+    expose:
+      default: true
+    exposedPort: 443
+    http:
+      tls:
+        enabled: true
+{% if traefik_acme_enabled | default(false) and traefik_wildcard_cert_enabled | default(false) %}
+        certResolver: letsencrypt
+        domains:
+          - main: "{{ traefik_wildcard_domain | default('*.' + environment_prefix + cluster_tld) }}"
+            sans:
+              - "{{ environment_prefix | regex_replace('\\.$', '') }}.{{ cluster_tld }}"
+{% endif %}
+  traefik:
+    port: 9000
+    expose:
+      default: false
+    exposedPort: 9000
+
+api:
+  dashboard: true
+  insecure: {{ traefik_dashboard_insecure | default(true) | lower }}
+
+providers:
+  kubernetesCRD:
+    enabled: true
+  kubernetesIngress:
+    enabled: true
+
+additionalArguments:
+  - "--providers.kubernetesingress.ingressclass=traefik"
+  - "--metrics.prometheus=true"
+{% if traefik_tls_enabled | default(false) %}
+  - "--entrypoints.websecure.http.tls=true"
+{% if traefik_acme_enabled | default(false) %}
+  - "--certificatesresolvers.letsencrypt.acme.dnschallenge=true"
+  - "--certificatesresolvers.letsencrypt.acme.dnschallenge.provider={{ traefik_acme_dns_provider | default('cloudflare') }}"
+  - "--certificatesresolvers.letsencrypt.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53"
+  - "--certificatesresolvers.letsencrypt.acme.dnschallenge.delaybeforecheck=10"
+  - "--certificatesresolvers.letsencrypt.acme.email={{ traefik_acme_email | default('admin@levangie.dev') }}"
+  - "--certificatesresolvers.letsencrypt.acme.storage=/data/acme.json"
+  - "--certificatesresolvers.letsencrypt.acme.caserver=https://acme-v02.api.letsencrypt.org/directory"
+{% else %}
+  - "--providers.file.directory=/data/dynamic"
+  - "--providers.file.watch=true"
+{% endif %}
+{% endif %}
+
+{% if traefik_persistence_enabled | default(false) %}
+persistence:
+  enabled: true
+  name: traefik-certs
+  size: 1Gi
+  storageClass: longhorn
+  path: /data
+  annotations: {}
+{% endif %}
+
+{% if traefik_acme_enabled | default(false) %}
+# Environment variables for DNS provider
+env:
+{% if traefik_acme_dns_provider == 'cloudflare' %}
+  - name: CF_API_EMAIL
+    valueFrom:
+      secretKeyRef:
+        name: traefik-dns-secret
+        key: email
+  - name: CF_DNS_API_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: traefik-dns-secret
+        key: api-token
+{% elif traefik_acme_dns_provider == 'route53' %}
+  - name: AWS_ACCESS_KEY_ID
+    valueFrom:
+      secretKeyRef:
+        name: traefik-dns-secret
+        key: access-key-id
+  - name: AWS_SECRET_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: traefik-dns-secret
+        key: secret-access-key
+{% endif %}
+
+securityContext:
+  runAsUser: 65532
+  runAsGroup: 65532
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+podSecurityContext:
+  runAsNonRoot: true
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+{% endif %}

--- a/argocd/apps/talos-test/external-secrets-config.yaml
+++ b/argocd/apps/talos-test/external-secrets-config.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets-config
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:jlevangi/home-infra.git
+    targetRevision: main
+    path: argocd/manifests/external-secrets-config/overlays/talos-test
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/apps/talos-test/external-secrets.yaml
+++ b/argocd/apps/talos-test/external-secrets.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://charts.external-secrets.io
+    chart: external-secrets
+    targetRevision: 0.10.5
+    helm:
+      values: |
+        installCRDs: true
+        replicaCount: 1
+        image:
+          repository: ghcr.io/external-secrets/external-secrets
+        webhook:
+          image:
+            repository: ghcr.io/external-secrets/external-secrets
+        certController:
+          image:
+            repository: ghcr.io/external-secrets/external-secrets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/apps/talos-test/gatus.yaml
+++ b/argocd/apps/talos-test/gatus.yaml
@@ -1,0 +1,81 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gatus
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://minicloudlabs.github.io/helm-charts
+    chart: gatus
+    targetRevision: 3.4.1
+    helm:
+      values: |
+        ingress:
+          enabled: true
+          ingressClassName: traefik
+          annotations:
+            traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+          hosts:
+            - status.talos-test.levangie.dev
+
+        persistence:
+          enabled: true
+          storageClassName: longhorn
+          size: 1Gi
+
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+
+        config:
+          storage:
+            type: sqlite
+            path: /data/data.db
+
+          endpoints:
+            - name: ArgoCD
+              group: Infrastructure
+              url: https://argocd.talos-test.levangie.dev
+              interval: 5m
+              conditions:
+                - "[STATUS] == 200"
+                - "[RESPONSE_TIME] < 5000"
+
+            - name: Grafana
+              group: Monitoring
+              url: https://grafana.talos-test.levangie.dev
+              interval: 5m
+              conditions:
+                - "[STATUS] == 200"
+                - "[RESPONSE_TIME] < 5000"
+
+            - name: Prometheus
+              group: Monitoring
+              url: http://prometheus-prometheus.monitoring.svc.cluster.local:9090/-/healthy
+              interval: 2m
+              conditions:
+                - "[STATUS] == 200"
+
+            - name: Microbin
+              group: Applications
+              url: https://bin.talos-test.levangie.dev
+              interval: 5m
+              conditions:
+                - "[STATUS] == 200"
+                - "[RESPONSE_TIME] < 5000"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: gatus
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/apps/talos-test/kube-prometheus-stack.yaml
+++ b/argocd/apps/talos-test/kube-prometheus-stack.yaml
@@ -35,7 +35,7 @@ spec:
             annotations:
               traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
             hosts:
-              - grafana.levangie.dev
+              - grafana.talos-test.levangie.dev
           persistence:
             enabled: true
             storageClassName: longhorn

--- a/argocd/apps/talos-test/kube-prometheus-stack.yaml
+++ b/argocd/apps/talos-test/kube-prometheus-stack.yaml
@@ -1,0 +1,138 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-prometheus-stack
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://prometheus-community.github.io/helm-charts
+    chart: kube-prometheus-stack
+    targetRevision: 67.4.0
+    helm:
+      values: |
+        fullnameOverride: prometheus
+
+        grafana:
+          enabled: true
+          admin:
+            existingSecret: grafana-admin-credentials
+            userKey: admin-user
+            passwordKey: admin-password
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          ingress:
+            enabled: true
+            ingressClassName: traefik
+            annotations:
+              traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+            hosts:
+              - grafana.levangie.dev
+          persistence:
+            enabled: true
+            storageClassName: longhorn
+            size: 2Gi
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          sidecar:
+            dashboards:
+              enabled: true
+              searchNamespace: ALL
+
+        prometheus:
+          prometheusSpec:
+            retention: 15d
+            resources:
+              requests:
+                cpu: 250m
+                memory: 512Mi
+              limits:
+                cpu: 1000m
+                memory: 2Gi
+            storageSpec:
+              volumeClaimTemplate:
+                spec:
+                  storageClassName: longhorn
+                  accessModes: ["ReadWriteOnce"]
+                  resources:
+                    requests:
+                      storage: 10Gi
+            serviceMonitorSelectorNilUsesHelmValues: false
+            podMonitorSelectorNilUsesHelmValues: false
+            ruleSelectorNilUsesHelmValues: false
+
+        alertmanager:
+          enabled: true
+          alertmanagerSpec:
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                cpu: 200m
+                memory: 256Mi
+            storage:
+              volumeClaimTemplate:
+                spec:
+                  storageClassName: longhorn
+                  accessModes: ["ReadWriteOnce"]
+                  resources:
+                    requests:
+                      storage: 2Gi
+
+        nodeExporter:
+          enabled: true
+        prometheus-node-exporter:
+          tolerations:
+            - key: CriticalAddonsOnly
+              operator: Equal
+              value: "true"
+              effect: NoExecute
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+
+        kube-state-metrics:
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+
+        kubeEtcd:
+          enabled: false
+        kubeScheduler:
+          enabled: false
+        kubeControllerManager:
+          enabled: false
+        kubeProxy:
+          enabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/argocd/apps/talos-test/monitoring-config.yaml
+++ b/argocd/apps/talos-test/monitoring-config.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: monitoring-config
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:jlevangi/home-infra.git
+    targetRevision: main
+    path: argocd/manifests/monitoring-config/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/apps/talos-test/vault.yaml
+++ b/argocd/apps/talos-test/vault.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://helm.releases.hashicorp.com
+    chart: vault
+    targetRevision: 0.28.0
+    helm:
+      values: |
+        global:
+          enabled: true
+          tlsDisable: true
+        injector:
+          enabled: false
+        csi:
+          enabled: false
+        server:
+          ha:
+            enabled: false
+          dataStorage:
+            enabled: true
+            size: 5Gi
+          ui:
+            enabled: true
+          ingress:
+            enabled: true
+            ingressClassName: traefik
+            annotations:
+              traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+            hosts:
+              - host: vault.talos-test.levangie.dev
+                paths:
+                  - /
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vault
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/manifests/external-secrets-config/overlays/talos-test/kustomization.yaml
+++ b/argocd/manifests/external-secrets-config/overlays/talos-test/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+commonLabels:
+  environment: talos-test

--- a/argocd/root-apps/root-talos-test.yaml
+++ b/argocd/root-apps/root-talos-test.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: git@github.com:jlevangi/home-infra.git
-    targetRevision: talos-test-cluster  # TODO: switch back to main after merge
+    targetRevision: main
     path: argocd/apps/talos-test
   destination:
     server: https://kubernetes.default.svc

--- a/argocd/root-apps/root-talos-test.yaml
+++ b/argocd/root-apps/root-talos-test.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: git@github.com:jlevangi/home-infra.git
-    targetRevision: main
+    targetRevision: talos-test-cluster  # TODO: switch back to main after merge
     path: argocd/apps/talos-test
   destination:
     server: https://kubernetes.default.svc

--- a/argocd/root-apps/root-talos-test.yaml
+++ b/argocd/root-apps/root-talos-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: root-talos-test
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:jlevangi/home-infra.git
+    targetRevision: main
+    path: argocd/apps/talos-test
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/scripts/deploy-talos-cluster.sh
+++ b/scripts/deploy-talos-cluster.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Deploy the Talos test cluster, configure local access, then bootstrap the
+# shared Kubernetes platform services (Longhorn, MetalLB, Traefik, ArgoCD,
+# Vault).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/environment-functions.sh"
+
+require_ansible_config || exit 1
+
+VERBOSITY=""
+SHOW_HELP=false
+AUTO_APPROVE=false
+MACHINE_CONFIG_APPLY_MODE="${TALOS_MACHINE_CONFIG_MODE:-auto}"
+
+require_command() {
+  local cmd="$1"
+  local reason="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "❌ Missing required command: $cmd" >&2
+    echo "   Needed for: $reason" >&2
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -v|--verbose)
+      VERBOSITY="-v"
+      shift
+      ;;
+    -vv)
+      VERBOSITY="-vv"
+      shift
+      ;;
+    -vvv)
+      VERBOSITY="-vvv"
+      shift
+      ;;
+    --auto-approve)
+      AUTO_APPROVE=true
+      shift
+      ;;
+    --initial-bootstrap)
+      MACHINE_CONFIG_APPLY_MODE="reported"
+      shift
+      ;;
+    --reconfigure)
+      MACHINE_CONFIG_APPLY_MODE="static"
+      shift
+      ;;
+    -h|--help)
+      SHOW_HELP=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${SHOW_HELP}" == "true" ]]; then
+  cat <<'EOF'
+Usage: scripts/deploy-talos-cluster.sh [options]
+
+Options:
+  -v, -vv, -vvv     Increase Ansible verbosity
+  --auto-approve    Pass -auto-approve to terraform apply
+  --initial-bootstrap
+                    Force Talos machine-config apply to use the guest-agent
+                    reported IPs. Use for the very first cluster bring-up.
+  --reconfigure     Force Talos machine-config apply to use the static Talos
+                    node IPs. Use for later config changes on an existing cluster.
+  -h, --help        Show this help and exit
+
+Environment:
+  TALOS_MACHINE_CONFIG_MODE=auto|reported|static
+EOF
+  exit 0
+fi
+
+TERRAFORM_DIR="${PROJECT_ROOT}/terraform/talos_cluster_test"
+LOCAL_KUBECONFIG_DIR="${HOME}/.kube"
+LOCAL_TALOSCONFIG_DIR="${HOME}/.talos"
+TALOS_KUBECONFIG="${LOCAL_KUBECONFIG_DIR}/config-talos-test"
+TALOSCONFIG_FILE="${LOCAL_TALOSCONFIG_DIR}/config-talos-test"
+TALOS_CONTEXT="talos-test"
+
+require_command terraform "Talos VM/bootstrap provisioning"
+require_command ansible-playbook "shared Kubernetes platform bootstrap"
+require_command kubectl "kubeconfig registration and cluster bootstrap"
+require_command helm "Longhorn, MetalLB, Traefik, and ArgoCD installation"
+require_command jq "Helm status parsing inside the shared platform role"
+
+if [[ ! -f "${HOME}/.ansible_vault_pass" ]]; then
+  echo "❌ Missing ~/.ansible_vault_pass" >&2
+  echo "   Needed for Ansible Vault secrets during platform bootstrap" >&2
+  exit 1
+fi
+
+mkdir -p "${LOCAL_KUBECONFIG_DIR}" "${LOCAL_TALOSCONFIG_DIR}"
+
+if [[ "${MACHINE_CONFIG_APPLY_MODE}" == "auto" ]]; then
+  if terraform -chdir="${TERRAFORM_DIR}" state list 2>/dev/null | grep -Fxq "talos_cluster_kubeconfig.this"; then
+    MACHINE_CONFIG_APPLY_MODE="static"
+  else
+    MACHINE_CONFIG_APPLY_MODE="reported"
+  fi
+fi
+
+echo "Using Talos machine-config apply mode: ${MACHINE_CONFIG_APPLY_MODE}"
+
+TF_CMD=(
+  terraform
+  -chdir="${TERRAFORM_DIR}"
+  apply
+  -var
+  "machine_config_apply_mode=${MACHINE_CONFIG_APPLY_MODE}"
+)
+if [[ "${AUTO_APPROVE}" == "true" ]]; then
+  TF_CMD+=(-auto-approve)
+fi
+
+echo "Deploying Talos test cluster with Terraform..."
+"${TF_CMD[@]}"
+
+echo "Writing local kubeconfig and talosconfig..."
+terraform -chdir="${TERRAFORM_DIR}" output -raw kubeconfig > "${TALOS_KUBECONFIG}"
+terraform -chdir="${TERRAFORM_DIR}" output -raw talosconfig > "${TALOSCONFIG_FILE}"
+chmod 600 "${TALOS_KUBECONFIG}" "${TALOSCONFIG_FILE}"
+
+echo "Registering kubectl context ${TALOS_CONTEXT}..."
+"${SCRIPT_DIR}/helpers/cluster-context-manager.sh" register-local "${TALOS_KUBECONFIG}" "${TALOS_CONTEXT}"
+
+ANSIBLE_CMD=(
+  ansible-playbook
+  "${PROJECT_ROOT}/ansible/playbooks/k8s-bootstrap-cluster.yml"
+  --vault-password-file
+  "${HOME}/.ansible_vault_pass"
+  -e
+  "target_cluster=talos_cluster_test"
+  -e
+  "kubeconfig_path=${TALOS_KUBECONFIG}"
+)
+
+if [[ -n "${VERBOSITY}" ]]; then
+  ANSIBLE_CMD+=("${VERBOSITY}")
+fi
+
+echo "Bootstrapping shared platform services on Talos..."
+"${ANSIBLE_CMD[@]}"
+
+echo
+echo "Talos cluster deployment complete."
+echo "kubectl context: ${TALOS_CONTEXT}"
+echo "kubeconfig: ${TALOS_KUBECONFIG}"
+echo "talosconfig: ${TALOSCONFIG_FILE}"

--- a/scripts/deploy-talos-cluster.sh
+++ b/scripts/deploy-talos-cluster.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Deploy the Talos test cluster, configure local access, then bootstrap the
+# Deploy a Talos cluster, configure local access, then bootstrap the
 # shared Kubernetes platform services (Longhorn, MetalLB, Traefik, ArgoCD,
 # Vault).
 
@@ -8,9 +8,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/lib/environment-functions.sh"
+ENVIRONMENTS_CONF="$SCRIPT_DIR/lib/talos-environments.conf"
 
 require_ansible_config || exit 1
 
+TARGET_ENV=""
 VERBOSITY=""
 SHOW_HELP=false
 AUTO_APPROVE=false
@@ -28,6 +30,22 @@ require_command() {
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --prod|--production)
+      TARGET_ENV="prod"
+      shift
+      ;;
+    --test)
+      TARGET_ENV="test"
+      shift
+      ;;
+    --stage|--staging)
+      TARGET_ENV="stage"
+      shift
+      ;;
+    --env)
+      TARGET_ENV="$2"
+      shift 2
+      ;;
     -v|--verbose)
       VERBOSITY="-v"
       shift
@@ -63,9 +81,13 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ "${SHOW_HELP}" == "true" ]]; then
+if [[ "${SHOW_HELP}" == "true" ]] || [[ -z "${TARGET_ENV}" ]]; then
   cat <<'EOF'
-Usage: scripts/deploy-talos-cluster.sh [options]
+Usage: scripts/deploy-talos-cluster.sh --test|--stage|--prod [options]
+
+EOF
+  show_environment_help "scripts/deploy-talos-cluster.sh" "Deploy"
+  cat <<'EOF'
 
 Options:
   -v, -vv, -vvv     Increase Ansible verbosity
@@ -80,15 +102,26 @@ Options:
 Environment:
   TALOS_MACHINE_CONFIG_MODE=auto|reported|static
 EOF
+  if [[ -z "${TARGET_ENV}" ]]; then
+    echo ""
+    echo "❌ Error: Target environment must be specified (--test, --stage, or --prod)"
+    exit 1
+  fi
   exit 0
 fi
 
-TERRAFORM_DIR="${PROJECT_ROOT}/terraform/talos_cluster_test"
+setup_environment_vars "${TARGET_ENV}" || exit 1
+
+if [[ -n "${DEFAULT_VERBOSITY}" && -z "${VERBOSITY}" ]]; then
+  VERBOSITY="${DEFAULT_VERBOSITY}"
+fi
+
+TERRAFORM_DIR="${PROJECT_ROOT}/terraform/${TARGET_CLUSTER}"
 LOCAL_KUBECONFIG_DIR="${HOME}/.kube"
 LOCAL_TALOSCONFIG_DIR="${HOME}/.talos"
-TALOS_KUBECONFIG="${LOCAL_KUBECONFIG_DIR}/config-talos-test"
-TALOSCONFIG_FILE="${LOCAL_TALOSCONFIG_DIR}/config-talos-test"
-TALOS_CONTEXT="talos-test"
+TALOS_KUBECONFIG="${LOCAL_KUBECONFIG_DIR}/config-${KUBECTL_CONTEXT}"
+TALOSCONFIG_FILE="${LOCAL_TALOSCONFIG_DIR}/config-${KUBECTL_CONTEXT}"
+TALOS_CONTEXT="${KUBECTL_CONTEXT}"
 
 require_command terraform "Talos VM/bootstrap provisioning"
 require_command ansible-playbook "shared Kubernetes platform bootstrap"
@@ -102,6 +135,12 @@ if [[ ! -f "${HOME}/.ansible_vault_pass" ]]; then
   exit 1
 fi
 
+if [[ ! -d "${TERRAFORM_DIR}" ]]; then
+  echo "❌ Terraform directory not found: ${TERRAFORM_DIR}" >&2
+  echo "   Create it before deploying the ${CLUSTER_NAME} Talos cluster" >&2
+  exit 1
+fi
+
 mkdir -p "${LOCAL_KUBECONFIG_DIR}" "${LOCAL_TALOSCONFIG_DIR}"
 
 if [[ "${MACHINE_CONFIG_APPLY_MODE}" == "auto" ]]; then
@@ -112,6 +151,7 @@ if [[ "${MACHINE_CONFIG_APPLY_MODE}" == "auto" ]]; then
   fi
 fi
 
+echo "${CLUSTER_EMOJI} Deploying ${CLUSTER_NAME} Talos cluster..."
 echo "Using Talos machine-config apply mode: ${MACHINE_CONFIG_APPLY_MODE}"
 
 TF_CMD=(
@@ -125,7 +165,7 @@ if [[ "${AUTO_APPROVE}" == "true" ]]; then
   TF_CMD+=(-auto-approve)
 fi
 
-echo "Deploying Talos test cluster with Terraform..."
+echo "Deploying Talos cluster with Terraform..."
 "${TF_CMD[@]}"
 
 echo "Writing local kubeconfig and talosconfig..."
@@ -142,7 +182,7 @@ ANSIBLE_CMD=(
   --vault-password-file
   "${HOME}/.ansible_vault_pass"
   -e
-  "target_cluster=talos_cluster_test"
+  "target_cluster=${TARGET_CLUSTER}"
   -e
   "kubeconfig_path=${TALOS_KUBECONFIG}"
 )
@@ -151,11 +191,11 @@ if [[ -n "${VERBOSITY}" ]]; then
   ANSIBLE_CMD+=("${VERBOSITY}")
 fi
 
-echo "Bootstrapping shared platform services on Talos..."
+echo "Bootstrapping shared platform services on ${CLUSTER_NAME} Talos cluster..."
 "${ANSIBLE_CMD[@]}"
 
 echo
-echo "Talos cluster deployment complete."
+echo "${CLUSTER_EMOJI} Talos cluster deployment complete."
 echo "kubectl context: ${TALOS_CONTEXT}"
 echo "kubeconfig: ${TALOS_KUBECONFIG}"
 echo "talosconfig: ${TALOSCONFIG_FILE}"

--- a/scripts/helpers/cluster-context-manager.sh
+++ b/scripts/helpers/cluster-context-manager.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Generic kubeconfig helper for locally-managed clusters such as Talos.
+
+set -euo pipefail
+
+LOCAL_KUBECONFIG_DIR="${HOME}/.kube"
+MASTER_KUBECONFIG="${LOCAL_KUBECONFIG_DIR}/config"
+
+mkdir -p "${LOCAL_KUBECONFIG_DIR}"
+
+show_usage() {
+    cat <<'EOF'
+Usage: cluster-context-manager.sh [register-local|switch|list|status] ...
+
+Commands:
+  register-local <config> <context>
+      Merge a kubeconfig file into ~/.kube/config and switch to <context>.
+  switch <context>
+      Switch kubectl to the named context.
+  list
+      List configured contexts.
+  status
+      Show the current context.
+EOF
+}
+
+register_local() {
+    local config_path="$1"
+    local context_name="$2"
+    local tmp_merge
+    local source_context
+    tmp_merge="$(mktemp)"
+
+    if [[ ! -f "${config_path}" ]]; then
+        echo "Missing kubeconfig: ${config_path}" >&2
+        exit 1
+    fi
+
+    source_context="$(kubectl config current-context --kubeconfig "${config_path}")"
+    if [[ -z "${source_context}" ]]; then
+        echo "Could not determine source context from ${config_path}" >&2
+        exit 1
+    fi
+
+    if [[ "${source_context}" != "${context_name}" ]]; then
+        kubectl config rename-context "${source_context}" "${context_name}" --kubeconfig "${config_path}" >/dev/null
+    fi
+
+    if [[ -f "${MASTER_KUBECONFIG}" ]]; then
+        KUBECONFIG="${MASTER_KUBECONFIG}:${config_path}" kubectl config view --flatten > "${tmp_merge}"
+        mv "${tmp_merge}" "${MASTER_KUBECONFIG}"
+    else
+        cp "${config_path}" "${MASTER_KUBECONFIG}"
+    fi
+
+    chmod 600 "${MASTER_KUBECONFIG}"
+    kubectl config use-context "${context_name}" >/dev/null
+    echo "Configured kubeconfig context: ${context_name}"
+}
+
+case "${1:-}" in
+    register-local)
+        [[ $# -eq 3 ]] || { show_usage >&2; exit 1; }
+        register_local "$2" "$3"
+        ;;
+    switch)
+        [[ $# -eq 2 ]] || { show_usage >&2; exit 1; }
+        kubectl config use-context "$2"
+        ;;
+    list)
+        kubectl config get-contexts
+        ;;
+    status)
+        kubectl config current-context
+        ;;
+    *)
+        show_usage >&2
+        exit 1
+        ;;
+esac

--- a/scripts/helpers/import-talos-template.sh
+++ b/scripts/helpers/import-talos-template.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# scripts/helpers/import-talos-template.sh
+#
+# Fetches a Talos Linux image from factory.talos.dev with the system
+# extensions our Talos Proxmox clusters need (qemu-guest-agent,
+# iscsi-tools, util-linux-tools) and imports it into Proxmox as a VM
+# template that terraform/talos_cluster_test/ clones from.
+#
+# Re-run for new Talos versions with a distinct --vmid/--name so prior
+# templates remain available for rollback. See the top of the file for
+# every overridable setting.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Defaults (every setting is overridable via env var or --flag).
+TALOS_VERSION="${TALOS_VERSION:-v1.12.6}"
+PROXMOX_HOST="${PROXMOX_HOST:-pve2}"
+PROXMOX_SSH_USER="${PROXMOX_SSH_USER:-root}"
+PROXMOX_STORAGE="${PROXMOX_STORAGE:-vm_data}"
+PROXMOX_BRIDGE="${PROXMOX_BRIDGE:-vmbr0}"
+TEMPLATE_VMID="${TEMPLATE_VMID:-9100}"
+TEMPLATE_NAME="${TEMPLATE_NAME:-}"
+IMAGE_VARIANT="${IMAGE_VARIANT:-nocloud-amd64.raw.xz}"
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Downloads a Talos Linux image (qemu-guest-agent + iscsi-tools +
+util-linux-tools pre-baked) from factory.talos.dev and turns it into a
+Proxmox VM template.
+
+Options (env var shown in parentheses):
+  --version <tag>   Talos version to pull      (TALOS_VERSION)      [$TALOS_VERSION]
+  --host <host>     Proxmox SSH host           (PROXMOX_HOST)       [$PROXMOX_HOST]
+  --user <user>     Proxmox SSH user           (PROXMOX_SSH_USER)   [$PROXMOX_SSH_USER]
+  --storage <name>  Proxmox storage for disk   (PROXMOX_STORAGE)    [$PROXMOX_STORAGE]
+  --bridge <name>   Proxmox network bridge     (PROXMOX_BRIDGE)     [$PROXMOX_BRIDGE]
+  --vmid <id>       Template VM id             (TEMPLATE_VMID)      [$TEMPLATE_VMID]
+  --name <name>     Template display name      (TEMPLATE_NAME)      [talos-<version>-template]
+  --variant <file>  Factory image variant      (IMAGE_VARIANT)      [$IMAGE_VARIANT]
+  -h, --help        Show this help and exit
+
+Requires: passwordless SSH to <user>@<host>; curl and xz on the Proxmox host.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version)  TALOS_VERSION="$2"; shift 2 ;;
+        --host)     PROXMOX_HOST="$2"; shift 2 ;;
+        --user)     PROXMOX_SSH_USER="$2"; shift 2 ;;
+        --storage)  PROXMOX_STORAGE="$2"; shift 2 ;;
+        --bridge)   PROXMOX_BRIDGE="$2"; shift 2 ;;
+        --vmid)     TEMPLATE_VMID="$2"; shift 2 ;;
+        --name)     TEMPLATE_NAME="$2"; shift 2 ;;
+        --variant)  IMAGE_VARIANT="$2"; shift 2 ;;
+        -h|--help)  usage; exit 0 ;;
+        *)
+            echo -e "${RED}Unknown argument: $1${NC}" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Fill in template name default now that --version may have changed.
+: "${TEMPLATE_NAME:=talos-${TALOS_VERSION}-template}"
+
+SSH_TARGET="${PROXMOX_SSH_USER}@${PROXMOX_HOST}"
+SSH=(ssh -o StrictHostKeyChecking=accept-new "$SSH_TARGET")
+
+echo -e "${BLUE}Building Talos factory schematic (qemu-guest-agent + iscsi-tools + util-linux-tools)${NC}"
+
+SCHEMATIC_YAML='customization:
+  systemExtensions:
+    officialExtensions:
+      - siderolabs/qemu-guest-agent
+      - siderolabs/iscsi-tools
+      - siderolabs/util-linux-tools
+'
+
+SCHEMATIC_RESPONSE=$(
+    curl -fsS -X POST \
+        --data-binary "$SCHEMATIC_YAML" \
+        https://factory.talos.dev/schematics
+)
+
+SCHEMATIC_ID=$(printf '%s' "$SCHEMATIC_RESPONSE" | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+if [[ -z "$SCHEMATIC_ID" ]]; then
+    echo -e "${RED}Could not parse schematic ID from factory response:${NC}" >&2
+    printf '%s\n' "$SCHEMATIC_RESPONSE" >&2
+    exit 1
+fi
+echo -e "${GREEN}Schematic ID: ${SCHEMATIC_ID}${NC}"
+
+IMAGE_URL="https://factory.talos.dev/image/${SCHEMATIC_ID}/${TALOS_VERSION}/${IMAGE_VARIANT}"
+echo -e "${BLUE}Image URL: ${IMAGE_URL}${NC}"
+echo -e "${BLUE}Target:    ${SSH_TARGET}  storage=${PROXMOX_STORAGE}  vmid=${TEMPLATE_VMID}  name=${TEMPLATE_NAME}${NC}"
+
+# Fail fast on unreachable SSH or clobbered VMID.
+if ! "${SSH[@]}" true 2>/dev/null; then
+    echo -e "${RED}Cannot SSH to ${SSH_TARGET}. Configure passwordless SSH first.${NC}" >&2
+    exit 1
+fi
+
+if "${SSH[@]}" "qm status ${TEMPLATE_VMID}" >/dev/null 2>&1; then
+    echo -e "${RED}A VM with id ${TEMPLATE_VMID} already exists on ${PROXMOX_HOST}.${NC}" >&2
+    echo -e "${YELLOW}  Use --vmid <new-id> to pick another slot, or destroy it:${NC}" >&2
+    echo -e "${YELLOW}    ssh ${SSH_TARGET} qm destroy ${TEMPLATE_VMID}${NC}" >&2
+    exit 1
+fi
+
+TMP_REMOTE="/tmp/talos-${TALOS_VERSION}-${SCHEMATIC_ID:0:8}"
+COMPRESSED_REMOTE="${TMP_REMOTE}/${IMAGE_VARIANT}"
+RAW_REMOTE="${TMP_REMOTE}/talos.raw"
+
+echo -e "${BLUE}Downloading image on the Proxmox host (no local transfer)${NC}"
+"${SSH[@]}" "mkdir -p '$TMP_REMOTE' && curl -fSL --retry 3 -o '$COMPRESSED_REMOTE' '$IMAGE_URL'"
+
+case "$IMAGE_VARIANT" in
+    *.raw.xz)
+        echo -e "${BLUE}Decompressing .xz${NC}"
+        "${SSH[@]}" "xz -dk -c '$COMPRESSED_REMOTE' > '$RAW_REMOTE'"
+        DISK_IMAGE="$RAW_REMOTE"
+        ;;
+    *.qcow2)
+        DISK_IMAGE="$COMPRESSED_REMOTE"
+        ;;
+    *)
+        echo -e "${RED}Unsupported IMAGE_VARIANT '${IMAGE_VARIANT}'. Use *.raw.xz or *.qcow2.${NC}" >&2
+        exit 1
+        ;;
+esac
+
+echo -e "${BLUE}Creating template VM ${TEMPLATE_VMID} (${TEMPLATE_NAME})${NC}"
+"${SSH[@]}" "qm create ${TEMPLATE_VMID} \
+    --name '${TEMPLATE_NAME}' \
+    --memory 2048 \
+    --cores 2 \
+    --cpu host \
+    --net0 virtio,bridge=${PROXMOX_BRIDGE} \
+    --scsihw virtio-scsi-pci \
+    --ostype l26 \
+    --agent enabled=1 \
+    --serial0 socket \
+    --vga serial0"
+
+echo -e "${BLUE}Importing disk into '${PROXMOX_STORAGE}'${NC}"
+"${SSH[@]}" "qm importdisk ${TEMPLATE_VMID} '${DISK_IMAGE}' ${PROXMOX_STORAGE}"
+
+# Attach imported disk, set boot order, convert to template.
+echo -e "${BLUE}Attaching disk and finalizing template${NC}"
+"${SSH[@]}" "qm set ${TEMPLATE_VMID} --scsi0 ${PROXMOX_STORAGE}:vm-${TEMPLATE_VMID}-disk-0"
+"${SSH[@]}" "qm set ${TEMPLATE_VMID} --boot order=scsi0"
+"${SSH[@]}" "qm template ${TEMPLATE_VMID}"
+
+echo -e "${BLUE}Cleaning up temp files on ${PROXMOX_HOST}${NC}"
+"${SSH[@]}" "rm -rf '$TMP_REMOTE'" || true
+
+echo ""
+echo -e "${GREEN}Template ready: ${TEMPLATE_NAME} (vmid ${TEMPLATE_VMID}) on ${PROXMOX_HOST}${NC}"
+echo -e "${YELLOW}Next:${NC} set 'template_name = \"${TEMPLATE_NAME}\"' in terraform/talos_cluster_test/terraform.tfvars"

--- a/scripts/helpers/talos-context-manager.sh
+++ b/scripts/helpers/talos-context-manager.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+# talos-context-manager.sh
+# Manage kubeconfig and talosconfig for Talos clusters.
+
+set -euo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_PROJECT_ROOT="$(cd "$_SCRIPT_DIR/../.." && pwd)"
+
+LOCAL_KUBECONFIG_DIR="${HOME}/.kube"
+LOCAL_TALOSCONFIG_DIR="${HOME}/.talos"
+MASTER_KUBECONFIG="${LOCAL_KUBECONFIG_DIR}/config"
+
+ENVIRONMENTS_CONF="${_PROJECT_ROOT}/scripts/lib/talos-environments.conf"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+mkdir -p "${LOCAL_KUBECONFIG_DIR}" "${LOCAL_TALOSCONFIG_DIR}"
+
+# Read a field from talos-environments.conf
+# Usage: get_env_field "test" 2  (1=name, 2=ansible_group, 3=display, 4=emoji, 5=context)
+get_env_field() {
+    local env="$1" field="$2"
+    grep "^${env}:" "${ENVIRONMENTS_CONF}" 2>/dev/null | cut -d: -f"${field}"
+}
+
+get_all_envs() {
+    grep -v '^#' "${ENVIRONMENTS_CONF}" | grep -v '^$' | cut -d: -f1
+}
+
+# Resolve paths for a given environment
+env_kubeconfig()  { echo "${LOCAL_KUBECONFIG_DIR}/config-talos-${1}"; }
+env_talosconfig() { echo "${LOCAL_TALOSCONFIG_DIR}/config-talos-${1}"; }
+env_context()     { get_env_field "$1" 5; }
+
+show_usage() {
+    cat <<EOF
+Usage: talos-context-manager.sh <command> [args]
+
+Commands:
+  setup [ENV]       Register kubeconfig + talosconfig for ENV (or all envs)
+  switch <ENV>      Switch kubectl and talosctl to the named environment
+  list              List configured Talos contexts and their status
+  status            Show current context info
+  aliases           Print shell aliases for all Talos environments
+
+Examples:
+  $0 setup test           # Register talos-test kubeconfig + talosconfig
+  $0 setup                # Register all available Talos environments
+  $0 switch test          # Switch to talos-test
+  $0 aliases              # Print aliases to eval in your shell
+
+Add to your shell profile:
+  eval "\$($0 aliases)"
+EOF
+}
+
+# Merge a kubeconfig into the master config and set the context name
+register_kubeconfig() {
+    local config_path="$1"
+    local context_name="$2"
+
+    if [[ ! -f "${config_path}" ]]; then
+        echo -e "${RED}Missing kubeconfig: ${config_path}${NC}" >&2
+        return 1
+    fi
+
+    # Remove any existing entries for this context to avoid stale certs
+    kubectl config delete-context "${context_name}" 2>/dev/null || true
+    kubectl config delete-cluster "${context_name}" 2>/dev/null || true
+
+    # Also clean up the authinfo name from the source config
+    local source_context
+    source_context="$(kubectl config current-context --kubeconfig "${config_path}" 2>/dev/null)" || true
+    if [[ -n "${source_context}" && "${source_context}" != "${context_name}" ]]; then
+        kubectl config delete-context "${source_context}" 2>/dev/null || true
+        kubectl config delete-user "${source_context}" 2>/dev/null || true
+        kubectl config rename-context "${source_context}" "${context_name}" --kubeconfig "${config_path}" >/dev/null 2>&1 || true
+    fi
+
+    local tmp_merge
+    tmp_merge="$(mktemp)"
+    if [[ -f "${MASTER_KUBECONFIG}" ]]; then
+        KUBECONFIG="${MASTER_KUBECONFIG}:${config_path}" kubectl config view --flatten > "${tmp_merge}"
+        mv "${tmp_merge}" "${MASTER_KUBECONFIG}"
+    else
+        cp "${config_path}" "${MASTER_KUBECONFIG}"
+    fi
+    chmod 600 "${MASTER_KUBECONFIG}"
+}
+
+# Register talosconfig: merge into ~/.talos/config or set as the active config
+register_talosconfig() {
+    local config_path="$1"
+    local context_name="$2"
+    local master_talosconfig="${LOCAL_TALOSCONFIG_DIR}/config"
+
+    if [[ ! -f "${config_path}" ]]; then
+        echo -e "${RED}Missing talosconfig: ${config_path}${NC}" >&2
+        return 1
+    fi
+
+    if command -v talosctl >/dev/null 2>&1; then
+        # Merge into the default talosconfig
+        if [[ -f "${master_talosconfig}" ]]; then
+            talosctl config merge "${config_path}" 2>/dev/null || cp "${config_path}" "${master_talosconfig}"
+        else
+            cp "${config_path}" "${master_talosconfig}"
+        fi
+        chmod 600 "${master_talosconfig}"
+    else
+        # talosctl not installed yet — just note the standalone path
+        echo -e "${YELLOW}  talosctl not found; talosconfig saved at ${config_path}${NC}"
+        echo -e "${YELLOW}  Install talosctl and use: talosctl --talosconfig ${config_path}${NC}"
+    fi
+}
+
+setup_env() {
+    local env="$1"
+    local display context kubeconfig talosconfig
+
+    display="$(get_env_field "${env}" 3)"
+    context="$(env_context "${env}")"
+    kubeconfig="$(env_kubeconfig "${env}")"
+    talosconfig="$(env_talosconfig "${env}")"
+
+    echo -e "${BLUE}Setting up ${display} Talos cluster (${context})...${NC}"
+
+    if [[ ! -f "${kubeconfig}" ]]; then
+        echo -e "${YELLOW}  Kubeconfig not found: ${kubeconfig}${NC}"
+        echo -e "${YELLOW}  Run deploy-talos-cluster.sh --${env} first${NC}"
+        return 1
+    fi
+
+    register_kubeconfig "${kubeconfig}" "${context}"
+    echo -e "${GREEN}  kubectl context '${context}' registered${NC}"
+
+    if [[ -f "${talosconfig}" ]]; then
+        register_talosconfig "${talosconfig}" "${context}"
+        echo -e "${GREEN}  talosconfig registered${NC}"
+    else
+        echo -e "${YELLOW}  No talosconfig found at ${talosconfig} (optional)${NC}"
+    fi
+
+    return 0
+}
+
+cmd_setup() {
+    local target="${1:-}"
+
+    if [[ -n "${target}" ]]; then
+        if ! get_env_field "${target}" 1 >/dev/null 2>&1 || [[ -z "$(get_env_field "${target}" 1)" ]]; then
+            echo -e "${RED}Unknown environment: ${target}${NC}" >&2
+            echo "Available: $(get_all_envs | tr '\n' ' ')" >&2
+            return 1
+        fi
+        setup_env "${target}"
+    else
+        echo -e "${BLUE}Setting up all Talos clusters...${NC}"
+        echo ""
+        local success=0 total=0
+        while IFS= read -r env; do
+            [[ -z "${env}" ]] && continue
+            total=$((total + 1))
+            if setup_env "${env}"; then
+                success=$((success + 1))
+            fi
+            echo ""
+        done <<< "$(get_all_envs)"
+        echo -e "${GREEN}Registered ${success}/${total} Talos clusters${NC}"
+    fi
+}
+
+cmd_switch() {
+    local env="${1:-}"
+    if [[ -z "${env}" ]]; then
+        echo "Usage: $0 switch <env>" >&2
+        echo "Available: $(get_all_envs | tr '\n' ' ')" >&2
+        return 1
+    fi
+
+    local context
+    context="$(env_context "${env}")"
+    if [[ -z "${context}" ]]; then
+        echo -e "${RED}Unknown environment: ${env}${NC}" >&2
+        return 1
+    fi
+
+    kubectl config use-context "${context}" 2>/dev/null || {
+        echo -e "${RED}Context '${context}' not found. Run '$0 setup ${env}' first.${NC}" >&2
+        return 1
+    }
+    echo -e "${GREEN}Switched kubectl to ${context}${NC}"
+
+    if command -v talosctl >/dev/null 2>&1; then
+        local talosconfig
+        talosconfig="$(env_talosconfig "${env}")"
+        if [[ -f "${talosconfig}" ]]; then
+            talosctl config context "${context}" 2>/dev/null || true
+            echo -e "${GREEN}Switched talosctl to ${context}${NC}"
+        fi
+    fi
+}
+
+cmd_list() {
+    echo -e "${BLUE}Talos cluster contexts:${NC}"
+    echo ""
+    printf "  %-12s %-14s %-30s %-30s\n" "ENV" "CONTEXT" "KUBECONFIG" "TALOSCONFIG"
+    printf "  %-12s %-14s %-30s %-30s\n" "---" "-------" "----------" "-----------"
+    while IFS= read -r env; do
+        [[ -z "${env}" ]] && continue
+        local context kubeconfig talosconfig kube_status talos_status
+        context="$(env_context "${env}")"
+        kubeconfig="$(env_kubeconfig "${env}")"
+        talosconfig="$(env_talosconfig "${env}")"
+        kube_status=$([[ -f "${kubeconfig}" ]] && echo "ok" || echo "missing")
+        talos_status=$([[ -f "${talosconfig}" ]] && echo "ok" || echo "missing")
+        printf "  %-12s %-14s %-30s %-30s\n" "${env}" "${context}" "${kube_status}" "${talos_status}"
+    done <<< "$(get_all_envs)"
+    echo ""
+
+    local current
+    current="$(kubectl config current-context 2>/dev/null)" || current="(none)"
+    echo -e "  Current kubectl context: ${current}"
+}
+
+cmd_status() {
+    local current
+    current="$(kubectl config current-context 2>/dev/null)" || current="(none)"
+    echo -e "${BLUE}Current context:${NC} ${current}"
+
+    if [[ "${current}" == talos-* ]] && timeout 5 kubectl cluster-info >/dev/null 2>&1; then
+        echo -e "${GREEN}Cluster is reachable${NC}"
+        kubectl get nodes -o wide
+    elif [[ "${current}" == talos-* ]]; then
+        echo -e "${RED}Cannot connect to cluster${NC}"
+    fi
+}
+
+cmd_aliases() {
+    echo "# Talos cluster context aliases"
+    echo "#   eval \"\$(${_PROJECT_ROOT}/scripts/helpers/talos-context-manager.sh aliases)\""
+    while IFS= read -r env; do
+        [[ -z "${env}" ]] && continue
+        local context
+        context="$(env_context "${env}")"
+        echo "alias ${context}='kubectl config use-context ${context}'"
+    done <<< "$(get_all_envs)"
+}
+
+case "${1:-}" in
+    setup)   cmd_setup "${2:-}" ;;
+    switch)  cmd_switch "${2:-}" ;;
+    list)    cmd_list ;;
+    status)  cmd_status ;;
+    aliases) cmd_aliases ;;
+    *)       show_usage >&2; exit 1 ;;
+esac

--- a/scripts/helpers/talos-shell-functions.sh
+++ b/scripts/helpers/talos-shell-functions.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# talos-shell-functions.sh
+# Shell functions for easy Talos cluster management
+# Source this file in your .bashrc or .zshrc: source ~/path/to/talos-shell-functions.sh
+
+# Get the directory of this script
+TALOS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Quick cluster switching functions
+function talos-prod() {
+    echo "Switching to Talos production cluster..."
+    "$TALOS_SCRIPT_DIR/talos-context-manager.sh" switch prod
+}
+
+function talos-test() {
+    echo "Switching to Talos test cluster..."
+    "$TALOS_SCRIPT_DIR/talos-context-manager.sh" switch test
+}
+
+function talos-stage() {
+    echo "Switching to Talos stage cluster..."
+    "$TALOS_SCRIPT_DIR/talos-context-manager.sh" switch stage
+}
+
+# Show current cluster status
+function talos-status() {
+    "$TALOS_SCRIPT_DIR/talos-context-manager.sh" status
+}
+
+# List all available Talos contexts
+function talos-list() {
+    "$TALOS_SCRIPT_DIR/talos-context-manager.sh" list
+}
+
+# Setup all Talos clusters
+function talos-setup() {
+    "$TALOS_SCRIPT_DIR/talos-context-manager.sh" setup "$@"
+}
+
+# Generic cluster switcher with tab completion
+function talos-switch() {
+    if [ -z "$1" ]; then
+        echo "Usage: talos-switch [prod|stage|test]"
+        return 1
+    fi
+    "$TALOS_SCRIPT_DIR/talos-context-manager.sh" switch "$1"
+}
+
+# Tab completion for talos-switch
+if command -v complete > /dev/null; then
+    complete -W "prod stage test" talos-switch
+fi
+
+# Show help for talos functions
+function talos-help() {
+    echo "Talos Cluster Management Functions:"
+    echo ""
+    echo "  talos-prod      - Switch to production cluster"
+    echo "  talos-stage     - Switch to stage cluster"
+    echo "  talos-test      - Switch to test cluster"
+    echo "  talos-switch    - Switch to specific cluster (with tab completion)"
+    echo "  talos-status    - Show current cluster status"
+    echo "  talos-list      - List all available Talos contexts"
+    echo "  talos-setup     - Setup/update Talos cluster configs"
+    echo ""
+    echo "Shared kubectl aliases (from k3s-shell-functions.sh):"
+    echo "  kgp, kgs, kgn, kga, kns, kdesc, klogs, kctx, kinfo"
+}
+
+echo "Talos cluster management functions loaded. Run 'talos-help' for usage."

--- a/scripts/lib/talos-environments.conf
+++ b/scripts/lib/talos-environments.conf
@@ -1,0 +1,15 @@
+# Environment Configuration for Talos Infrastructure Scripts
+# This file defines all available Talos cluster environments and their properties
+#
+# Format: environment_name:ansible_group:display_name:emoji:kubectl_context:default_verbosity
+#
+# environment_name: Short name used in --env flag (e.g., "prod", "test", "stage")
+# ansible_group: Ansible group_vars file name (e.g., "talos_cluster_test")
+# display_name: Human-readable name for output (e.g., "Production", "Test")
+# emoji: Emoji for visual identification in output
+# kubectl_context: Context name for cluster-context-manager.sh
+# default_verbosity: Default verbosity level ("" for standard, "-v" for verbose)
+
+test:talos_cluster_test:Test:🧪:talos-test:-v
+stage:talos_cluster_stage:Staging:🎭:talos-stage:-v
+prod:talos_cluster_prod:Production:🚀:talos-prod:

--- a/terraform/k3_3node_cluster_prod/main.tf
+++ b/terraform/k3_3node_cluster_prod/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     proxmox = {
       source = "telmate/proxmox"
-      version = "3.0.2-rc03"
+      version = "3.0.2-rc07"
     }
   }
   required_version = ">= 1.0"

--- a/terraform/k3_3node_cluster_stage/main.tf
+++ b/terraform/k3_3node_cluster_stage/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     proxmox = {
       source = "telmate/proxmox"
-      version = "3.0.2-rc03"
+      version = "3.0.2-rc07"
     }
   }
   required_version = ">= 1.0"

--- a/terraform/k3_3node_cluster_test/main.tf
+++ b/terraform/k3_3node_cluster_test/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     proxmox = {
       source = "telmate/proxmox"
-      version = "3.0.2-rc03"
+      version = "3.0.2-rc07"
     }
   }
   required_version = ">= 1.0"

--- a/terraform/talos_cluster_test/main.tf
+++ b/terraform/talos_cluster_test/main.tf
@@ -46,14 +46,20 @@ locals {
   # Allow `nameserver` tfvar to hold a single IP or a comma-separated list.
   nameservers = [for n in split(",", var.nameserver) : trimspace(n) if trimspace(n) != ""]
 
-  # Per-node machine config patch: hostname, static IP, install disk.
-  # Applied on top of the base controlplane/worker config produced by the
-  # talos_machine_configuration data source below.
-  node_patch = {
+  # Per-node patches applied on top of the base controlplane/worker config
+  # produced by the talos_machine_configuration data source below.
+  #
+  # Two patches per node:
+  #   1. v1alpha1 strategic-merge patch for install disk + static network
+  #   2. Standalone HostnameConfig document (Talos 1.12 moved hostname out of
+  #      v1alpha1 machine.network.hostname; setting it in both places now
+  #      fails validation with "static hostname is already set in v1alpha1
+  #      config"). HostnameConfig accepts either `hostname: <name>` for an
+  #      explicit value or `auto: stable` for a derived one.
+  node_network_patch = {
     for name, cfg in local.nodes : name => yamlencode({
       machine = {
         network = {
-          hostname    = name
           nameservers = local.nameservers
           interfaces = [{
             deviceSelector = {
@@ -70,6 +76,14 @@ locals {
           disk = var.install_disk
         }
       }
+    })
+  }
+
+  node_hostname_patch = {
+    for name, _ in local.nodes : name => yamlencode({
+      apiVersion = "v1alpha1"
+      kind       = "HostnameConfig"
+      hostname   = name
     })
   }
 }
@@ -92,6 +106,9 @@ resource "proxmox_vm_qemu" "talos" {
   start_at_node_boot = false
 
   agent = 1
+  # Our bridge has no IPv6 — skip IPv6 address discovery via qemu-guest-agent
+  # to avoid a harmless-but-noisy "no IPv6 address is found" warning on plan.
+  skip_ipv6 = true
 
   cpu {
     cores   = var.vm_cores
@@ -169,7 +186,10 @@ resource "talos_machine_configuration_apply" "controlplane" {
   node                        = proxmox_vm_qemu.talos[each.key].default_ipv4_address
   endpoint                    = proxmox_vm_qemu.talos[each.key].default_ipv4_address
 
-  config_patches = [local.node_patch[each.key]]
+  config_patches = [
+    local.node_network_patch[each.key],
+    local.node_hostname_patch[each.key],
+  ]
 
   depends_on = [proxmox_vm_qemu.talos]
 
@@ -188,7 +208,10 @@ resource "talos_machine_configuration_apply" "worker" {
   node                        = proxmox_vm_qemu.talos[each.key].default_ipv4_address
   endpoint                    = proxmox_vm_qemu.talos[each.key].default_ipv4_address
 
-  config_patches = [local.node_patch[each.key]]
+  config_patches = [
+    local.node_network_patch[each.key],
+    local.node_hostname_patch[each.key],
+  ]
 
   depends_on = [proxmox_vm_qemu.talos]
 

--- a/terraform/talos_cluster_test/main.tf
+++ b/terraform/talos_cluster_test/main.tf
@@ -44,7 +44,8 @@ locals {
   worker_nodes       = { for k, v in local.nodes : k => v if v.role == "worker" }
 
   # Allow `nameserver` tfvar to hold a single IP or a comma-separated list.
-  nameservers = [for n in split(",", var.nameserver) : trimspace(n) if trimspace(n) != ""]
+  nameservers                         = [for n in split(",", var.nameserver) : trimspace(n) if trimspace(n) != ""]
+  talos_longhorn_volume_disk_selector = var.talos_longhorn_volume_disk_selector != "" ? var.talos_longhorn_volume_disk_selector : "disk.dev_path == '${var.install_disk}'"
 
   # Per-node patches applied on top of the base controlplane/worker config
   # produced by the talos_machine_configuration data source below.
@@ -86,6 +87,40 @@ locals {
       kind       = "HostnameConfig"
       auto       = "off"
       hostname   = name
+    })
+  }
+
+  # Longhorn on Talos 1.10+ should use a user volume mounted under
+  # /var/mnt/<name>, then expose that path explicitly to kubelet so Longhorn
+  # CSI components can reach the host path.
+  node_longhorn_kubelet_patch = {
+    for name, _ in local.nodes : name => yamlencode({
+      machine = {
+        kubelet = {
+          extraMounts = [{
+            destination = var.talos_longhorn_data_path
+            type        = "bind"
+            source      = var.talos_longhorn_data_path
+            options     = ["bind", "rshared", "rw"]
+          }]
+        }
+      }
+    })
+  }
+
+  node_longhorn_user_volume_patch = {
+    for name, _ in local.nodes : name => yamlencode({
+      apiVersion = "v1alpha1"
+      kind       = "UserVolumeConfig"
+      name       = var.talos_longhorn_volume_name
+      provisioning = {
+        diskSelector = {
+          match = local.talos_longhorn_volume_disk_selector
+        }
+        grow    = false
+        minSize = var.talos_longhorn_volume_min_size
+        maxSize = var.talos_longhorn_volume_max_size
+      }
     })
   }
 }
@@ -179,27 +214,26 @@ data "talos_client_configuration" "this" {
 # reports its IP via qemu-guest-agent (bundled in the Talos template image).
 # We reach it at that DHCP address to apply the real config, which includes
 # the static IP patch from locals.node_patch above. After apply, Talos reboots
-# into its configured state on the static IP.
+# into its configured state on the static IP. Subsequent reconfiguration must
+# target the static IP directly because the reported guest-agent address may be
+# a transient DHCP/maintenance address that is not routable from the operator
+# machine.
 resource "talos_machine_configuration_apply" "controlplane" {
   for_each = local.controlplane_nodes
 
   client_configuration        = talos_machine_secrets.this.client_configuration
   machine_configuration_input = data.talos_machine_configuration.controlplane.machine_configuration
-  node                        = proxmox_vm_qemu.talos[each.key].default_ipv4_address
-  endpoint                    = proxmox_vm_qemu.talos[each.key].default_ipv4_address
+  node                        = var.machine_config_apply_mode == "static" ? each.value.ip : proxmox_vm_qemu.talos[each.key].default_ipv4_address
+  endpoint                    = var.machine_config_apply_mode == "static" ? each.value.ip : proxmox_vm_qemu.talos[each.key].default_ipv4_address
 
   config_patches = [
     local.node_network_patch[each.key],
+    local.node_longhorn_kubelet_patch[each.key],
+    local.node_longhorn_user_volume_patch[each.key],
     local.node_hostname_patch[each.key],
   ]
 
   depends_on = [proxmox_vm_qemu.talos]
-
-  lifecycle {
-    # After the first apply, the node reboots to its static IP, so
-    # default_ipv4_address changes. Don't trigger re-applies on that drift.
-    ignore_changes = [node, endpoint]
-  }
 }
 
 resource "talos_machine_configuration_apply" "worker" {
@@ -207,19 +241,17 @@ resource "talos_machine_configuration_apply" "worker" {
 
   client_configuration        = talos_machine_secrets.this.client_configuration
   machine_configuration_input = data.talos_machine_configuration.worker.machine_configuration
-  node                        = proxmox_vm_qemu.talos[each.key].default_ipv4_address
-  endpoint                    = proxmox_vm_qemu.talos[each.key].default_ipv4_address
+  node                        = var.machine_config_apply_mode == "static" ? each.value.ip : proxmox_vm_qemu.talos[each.key].default_ipv4_address
+  endpoint                    = var.machine_config_apply_mode == "static" ? each.value.ip : proxmox_vm_qemu.talos[each.key].default_ipv4_address
 
   config_patches = [
     local.node_network_patch[each.key],
+    local.node_longhorn_kubelet_patch[each.key],
+    local.node_longhorn_user_volume_patch[each.key],
     local.node_hostname_patch[each.key],
   ]
 
   depends_on = [proxmox_vm_qemu.talos]
-
-  lifecycle {
-    ignore_changes = [node, endpoint]
-  }
 }
 
 # --- Bootstrap etcd on the controlplane ------------------------------------

--- a/terraform/talos_cluster_test/main.tf
+++ b/terraform/talos_cluster_test/main.tf
@@ -52,10 +52,11 @@ locals {
   # Two patches per node:
   #   1. v1alpha1 strategic-merge patch for install disk + static network
   #   2. Standalone HostnameConfig document (Talos 1.12 moved hostname out of
-  #      v1alpha1 machine.network.hostname; setting it in both places now
-  #      fails validation with "static hostname is already set in v1alpha1
-  #      config"). HostnameConfig accepts either `hostname: <name>` for an
-  #      explicit value or `auto: stable` for a derived one.
+  #      v1alpha1 machine.network.hostname. The default machine config already
+  #      includes `auto: stable`, so when overriding with an explicit
+  #      hostname we must also disable auto-generation or Talos rejects the
+  #      merged document with "'auto' and 'hostname' cannot be set at the same
+  #      time".
   node_network_patch = {
     for name, cfg in local.nodes : name => yamlencode({
       machine = {
@@ -83,6 +84,7 @@ locals {
     for name, _ in local.nodes : name => yamlencode({
       apiVersion = "v1alpha1"
       kind       = "HostnameConfig"
+      auto       = "off"
       hostname   = name
     })
   }

--- a/terraform/talos_cluster_test/main.tf
+++ b/terraform/talos_cluster_test/main.tf
@@ -1,0 +1,223 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    proxmox = {
+      source  = "telmate/proxmox"
+      version = "3.0.2-rc07"
+    }
+    talos = {
+      source  = "siderolabs/talos"
+      version = "~> 0.7"
+    }
+  }
+}
+
+provider "proxmox" {
+  pm_api_url          = var.api_url
+  pm_api_token_id     = var.token_id
+  pm_api_token_secret = var.token_secret
+  pm_tls_insecure     = true
+  pm_log_enable       = true
+  pm_log_file         = "tf-plugin-proxmox.log"
+  pm_debug            = true
+  pm_log_levels = {
+    _default    = "debug"
+    _capturelog = ""
+  }
+}
+
+# Cluster layout: 1 controlplane + 2 workers. Mirror of the Debian/K3s test
+# cluster node count (k3s_3node_cluster_test) but running Talos + upstream
+# K8s instead of K3s on Debian.
+locals {
+  cluster_name     = var.cluster_name
+  cluster_endpoint = "https://${var.controlplane_ip}:6443"
+
+  nodes = {
+    "${var.vm_name}-1" = { ip = "${var.ip_base}1", role = "controlplane" }
+    "${var.vm_name}-2" = { ip = "${var.ip_base}2", role = "worker" }
+    "${var.vm_name}-3" = { ip = "${var.ip_base}3", role = "worker" }
+  }
+
+  controlplane_nodes = { for k, v in local.nodes : k => v if v.role == "controlplane" }
+  worker_nodes       = { for k, v in local.nodes : k => v if v.role == "worker" }
+
+  # Allow `nameserver` tfvar to hold a single IP or a comma-separated list.
+  nameservers = [for n in split(",", var.nameserver) : trimspace(n) if trimspace(n) != ""]
+
+  # Per-node machine config patch: hostname, static IP, install disk.
+  # Applied on top of the base controlplane/worker config produced by the
+  # talos_machine_configuration data source below.
+  node_patch = {
+    for name, cfg in local.nodes : name => yamlencode({
+      machine = {
+        network = {
+          hostname    = name
+          nameservers = local.nameservers
+          interfaces = [{
+            deviceSelector = {
+              driver = "virtio_net"
+            }
+            addresses = ["${cfg.ip}/${var.subnet_mask}"]
+            routes = [{
+              network = "0.0.0.0/0"
+              gateway = var.gateway
+            }]
+          }]
+        }
+        install = {
+          disk = var.install_disk
+        }
+      }
+    })
+  }
+}
+
+# --- Proxmox VMs ------------------------------------------------------------
+# Cloned from the Talos template produced by
+# scripts/helpers/import-talos-template.sh. Talos ignores cloud-init, so we
+# deliberately omit ciuser/cipassword/sshkeys/ipconfig0/nameserver/searchdomain
+# and the cloud-init ide2 drive — IP assignment happens via the Talos machine
+# config patch below.
+resource "proxmox_vm_qemu" "talos" {
+  for_each = local.nodes
+
+  name        = each.key
+  target_node = var.proxmox_hosts
+  clone       = var.template_name
+  full_clone  = true
+
+  # Test cluster: do not auto-start when the Proxmox host boots.
+  start_at_node_boot = false
+
+  agent = 1
+
+  cpu {
+    cores   = var.vm_cores
+    sockets = 1
+    type    = "host"
+  }
+  memory   = var.vm_memory
+  scsihw   = "virtio-scsi-pci"
+  bootdisk = "scsi0"
+
+  disk {
+    slot    = "scsi0"
+    size    = var.vm_disk_size
+    type    = "disk"
+    storage = var.vm_storage
+  }
+
+  network {
+    id     = 0
+    model  = "virtio"
+    bridge = var.nic_name
+  }
+
+  timeouts {
+    create = "30m"
+    update = "15m"
+    delete = "10m"
+  }
+
+  lifecycle {
+    # Clones may show spurious diffs on disk/network after first apply and
+    # the qemu-agent-reported IP changes once the Talos static config takes
+    # effect — ignore both to keep re-applies quiet.
+    ignore_changes = [network, disk]
+  }
+}
+
+# --- Talos secrets and per-role machine config -----------------------------
+resource "talos_machine_secrets" "this" {}
+
+data "talos_machine_configuration" "controlplane" {
+  cluster_name     = local.cluster_name
+  cluster_endpoint = local.cluster_endpoint
+  machine_type     = "controlplane"
+  machine_secrets  = talos_machine_secrets.this.machine_secrets
+}
+
+data "talos_machine_configuration" "worker" {
+  cluster_name     = local.cluster_name
+  cluster_endpoint = local.cluster_endpoint
+  machine_type     = "worker"
+  machine_secrets  = talos_machine_secrets.this.machine_secrets
+}
+
+# Talos client config (for `talosctl` once `terraform output -raw talosconfig`
+# is redirected to a file).
+data "talos_client_configuration" "this" {
+  cluster_name         = local.cluster_name
+  client_configuration = talos_machine_secrets.this.client_configuration
+  endpoints            = [for _, v in local.controlplane_nodes : v.ip]
+  nodes                = [for _, v in local.nodes : v.ip]
+}
+
+# --- Apply machine config to each node -------------------------------------
+# First boot: Talos comes up in maintenance mode, takes a DHCP lease, and
+# reports its IP via qemu-guest-agent (bundled in the Talos template image).
+# We reach it at that DHCP address to apply the real config, which includes
+# the static IP patch from locals.node_patch above. After apply, Talos reboots
+# into its configured state on the static IP.
+resource "talos_machine_configuration_apply" "controlplane" {
+  for_each = local.controlplane_nodes
+
+  client_configuration        = talos_machine_secrets.this.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.controlplane.machine_configuration
+  node                        = proxmox_vm_qemu.talos[each.key].default_ipv4_address
+  endpoint                    = proxmox_vm_qemu.talos[each.key].default_ipv4_address
+
+  config_patches = [local.node_patch[each.key]]
+
+  depends_on = [proxmox_vm_qemu.talos]
+
+  lifecycle {
+    # After the first apply, the node reboots to its static IP, so
+    # default_ipv4_address changes. Don't trigger re-applies on that drift.
+    ignore_changes = [node, endpoint]
+  }
+}
+
+resource "talos_machine_configuration_apply" "worker" {
+  for_each = local.worker_nodes
+
+  client_configuration        = talos_machine_secrets.this.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.worker.machine_configuration
+  node                        = proxmox_vm_qemu.talos[each.key].default_ipv4_address
+  endpoint                    = proxmox_vm_qemu.talos[each.key].default_ipv4_address
+
+  config_patches = [local.node_patch[each.key]]
+
+  depends_on = [proxmox_vm_qemu.talos]
+
+  lifecycle {
+    ignore_changes = [node, endpoint]
+  }
+}
+
+# --- Bootstrap etcd on the controlplane ------------------------------------
+# Target the static controlplane IP — after the config apply above, the node
+# is reachable there.
+resource "talos_machine_bootstrap" "this" {
+  client_configuration = talos_machine_secrets.this.client_configuration
+  node                 = var.controlplane_ip
+  endpoint             = var.controlplane_ip
+
+  depends_on = [
+    talos_machine_configuration_apply.controlplane,
+    talos_machine_configuration_apply.worker,
+  ]
+}
+
+# --- Fetch kubeconfig ------------------------------------------------------
+# Resource (not data source) — the data source form is deprecated in
+# siderolabs/talos v0.10+ and slated for removal in the next minor release.
+resource "talos_cluster_kubeconfig" "this" {
+  client_configuration = talos_machine_secrets.this.client_configuration
+  node                 = var.controlplane_ip
+  endpoint             = var.controlplane_ip
+
+  depends_on = [talos_machine_bootstrap.this]
+}

--- a/terraform/talos_cluster_test/outputs.tf
+++ b/terraform/talos_cluster_test/outputs.tf
@@ -1,0 +1,30 @@
+output "vm_names" {
+  description = "Names of the Talos nodes (maps to Proxmox VM names)"
+  value       = [for k, _ in local.nodes : k]
+}
+
+output "vm_ips" {
+  description = "Static IPs assigned to each Talos node"
+  value       = { for k, v in local.nodes : k => v.ip }
+}
+
+output "controlplane_endpoint" {
+  description = "Kubernetes / Talos API endpoint"
+  value       = local.cluster_endpoint
+}
+
+# Write to disk with:
+#   terraform output -raw kubeconfig > ~/.kube/config-talos-test
+output "kubeconfig" {
+  description = "Raw kubeconfig for the Talos cluster"
+  value       = talos_cluster_kubeconfig.this.kubeconfig_raw
+  sensitive   = true
+}
+
+# Write to disk with:
+#   terraform output -raw talosconfig > ~/.talos/config-talos-test
+output "talosconfig" {
+  description = "Raw talosconfig for talosctl"
+  value       = data.talos_client_configuration.this.talos_config
+  sensitive   = true
+}

--- a/terraform/talos_cluster_test/variables.tf
+++ b/terraform/talos_cluster_test/variables.tf
@@ -1,0 +1,106 @@
+# Proxmox connection
+variable "api_url" {
+  description = "Proxmox API URL"
+  type        = string
+  default     = "https://172.20.20.12:8006/api2/json"
+}
+
+variable "token_id" {
+  description = "Proxmox API token ID"
+  type        = string
+}
+
+variable "token_secret" {
+  description = "Proxmox API token secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "proxmox_hosts" {
+  description = "Proxmox node to create VMs on"
+  type        = string
+  default     = "pve2"
+}
+
+# Template + naming
+variable "template_name" {
+  description = "Name of the Talos template VM to clone (produced by scripts/helpers/import-talos-template.sh)"
+  type        = string
+  default     = "talos-v1.12.6-template"
+}
+
+variable "vm_name" {
+  description = "Base name for cluster VMs; nodes will be named <vm_name>-1..N"
+  type        = string
+  default     = "talos-test-node"
+}
+
+variable "cluster_name" {
+  description = "Talos cluster name (used in machine secrets, kubeconfig, talosconfig)"
+  type        = string
+  default     = "talos-test"
+}
+
+# VM sizing
+variable "vm_cores" {
+  description = "CPU cores per node"
+  type        = number
+  default     = 2
+}
+
+variable "vm_memory" {
+  description = "Memory in MB per node"
+  type        = number
+  default     = 4096
+}
+
+variable "vm_disk_size" {
+  description = "Root disk size per node"
+  type        = string
+  default     = "20G"
+}
+
+variable "vm_storage" {
+  description = "Proxmox storage for the VM disk"
+  type        = string
+  default     = "vm_data"
+}
+
+variable "nic_name" {
+  description = "Proxmox bridge interface"
+  type        = string
+  default     = "vmbr0"
+}
+
+# Network
+variable "ip_base" {
+  description = "Base IP for the cluster (e.g. '172.20.20.13' -> nodes at .131/.132/.133)"
+  type        = string
+}
+
+variable "controlplane_ip" {
+  description = "Full static IP of the controlplane node (used as Talos / K8s API endpoint)"
+  type        = string
+}
+
+variable "subnet_mask" {
+  description = "Subnet prefix length"
+  type        = string
+}
+
+variable "gateway" {
+  description = "Default gateway"
+  type        = string
+}
+
+variable "nameserver" {
+  description = "Upstream DNS server"
+  type        = string
+}
+
+# Talos
+variable "install_disk" {
+  description = "Block device Talos should install/upgrade onto"
+  type        = string
+  default     = "/dev/sda"
+}

--- a/terraform/talos_cluster_test/variables.tf
+++ b/terraform/talos_cluster_test/variables.tf
@@ -104,3 +104,44 @@ variable "install_disk" {
   type        = string
   default     = "/dev/sda"
 }
+
+variable "machine_config_apply_mode" {
+  description = "How talos_machine_configuration_apply should reach nodes: 'reported' uses the QEMU guest-agent IPv4 on first boot, 'static' uses the configured Talos node IPs for reconfiguration."
+  type        = string
+  default     = "reported"
+
+  validation {
+    condition     = contains(["reported", "static"], var.machine_config_apply_mode)
+    error_message = "machine_config_apply_mode must be either 'reported' or 'static'."
+  }
+}
+
+variable "talos_longhorn_data_path" {
+  description = "Host path Longhorn should use on Talos nodes."
+  type        = string
+  default     = "/var/mnt/longhorn"
+}
+
+variable "talos_longhorn_volume_name" {
+  description = "Talos UserVolumeConfig name for the Longhorn data volume. Mounted at /var/mnt/<name>."
+  type        = string
+  default     = "longhorn"
+}
+
+variable "talos_longhorn_volume_disk_selector" {
+  description = "CEL expression used by Talos UserVolumeConfig to select the disk for the Longhorn volume."
+  type        = string
+  default     = ""
+}
+
+variable "talos_longhorn_volume_min_size" {
+  description = "Minimum size for the Talos Longhorn user volume."
+  type        = string
+  default     = "2GiB"
+}
+
+variable "talos_longhorn_volume_max_size" {
+  description = "Maximum size for the Talos Longhorn user volume."
+  type        = string
+  default     = "8GiB"
+}


### PR DESCRIPTION
## Summary

- **Talos Linux test cluster**: Terraform configs (`talos_cluster_test/`) for provisioning Talos nodes on Proxmox VE with Talos provider
- **Shared k8s_platform role**: Reusable Ansible role for platform services (Longhorn, MetalLB, Traefik, ArgoCD, Vault) that works for both K3s and Talos clusters
- **Multi-environment deploy script**: `deploy-talos-cluster.sh` with `--test`/`--stage`/`--prod` flags, matching the K3s script pattern
- **Talos context management**: Dedicated `talos-context-manager.sh` handling both kubeconfig and talosconfig, with shell functions for quick switching
- **ArgoCD apps for talos-test**: Vault, external-secrets, monitoring (kube-prometheus-stack + Gatus), with path-based environment separation
- **Vault unseal maintenance playbook**: Automates the full recovery flow (unseal, refresh K8s auth, restart external-secrets, verify) for any cluster
- **Proxmox v9 compatibility**: Updated telmate provider to 3.0.2-rc07 across all environments
- **Longhorn DNS fix**: Corrected CNAME subdomain ordering in both k3s and k8s_platform roles

## Test plan

- [ ] `./scripts/deploy-talos-cluster.sh --test` provisions and bootstraps the talos-test cluster
- [ ] `./scripts/deploy-k3s-cluster.sh --test` still works for K3s (no regression)
- [ ] `talos-test` / `talos-prod` shell functions switch contexts correctly
- [ ] ArgoCD syncs apps from `argocd/apps/talos-test/` on main
- [ ] `ansible-playbook ansible/playbooks/maintenance/vault-unseal.yml -e kubectl_context=k3s-prod` recovers Vault + ExternalSecrets
- [ ] Terraform init/plan succeeds for prod and stage with updated telmate provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)