### PR TITLE
[codex] Guard Vault unseal secret parsing

### DIFF
--- a/ansible/playbooks/maintenance/vault-unseal.yml
+++ b/ansible/playbooks/maintenance/vault-unseal.yml
@@ -122,6 +122,7 @@
       register: vault_init_secret_raw
       when: vault_sealed | default(true)
       no_log: true
+      when: vault_sealed | default(true)
 
     - name: Parse unseal keys and root token
       set_fact:
@@ -131,6 +132,9 @@
           - "{{ (vault_init_secret_raw.stdout | from_json).data['unseal-key-3'] | b64decode }}"
         vault_root_token: "{{ (vault_init_secret_raw.stdout | from_json).data['root-token'] | b64decode }}"
       no_log: true
+      when:
+        - vault_sealed | default(true)
+        - vault_init_secret_raw.stdout | default('') | length > 0
 
     - name: Unseal primary Vault pod
       shell: >
@@ -209,6 +213,23 @@
       set_fact:
         vault_root_token: "{{ vault_root_token_raw.stdout | b64decode }}"
       when: vault_root_token is not defined
+      no_log: true
+
+    # ── Read root token (if we did not need the unseal path) ─────────
+    - name: Read root token from secret
+      shell: >
+        kubectl --context {{ kubectl_context }} get secret {{ vault_init_secret_name }}
+        -n {{ vault_namespace }} -o jsonpath='{.data.root-token}'
+      register: vault_root_token_raw
+      when: vault_root_token is not defined
+      no_log: true
+
+    - name: Set root token
+      set_fact:
+        vault_root_token: "{{ vault_root_token_raw.stdout | b64decode }}"
+      when:
+        - vault_root_token is not defined
+        - vault_root_token_raw.stdout | default('') | length > 0
       no_log: true
 
     # ── Reconfigure Kubernetes auth ───────────────────────────────────

--- a/ansible/playbooks/maintenance/vault-unseal.yml
+++ b/ansible/playbooks/maintenance/vault-unseal.yml
@@ -120,7 +120,6 @@
         kubectl --context {{ kubectl_context }} get secret {{ vault_init_secret_name }}
         -n {{ vault_namespace }} -o json
       register: vault_init_secret_raw
-      when: vault_sealed | default(true)
       no_log: true
       when: vault_sealed | default(true)
 


### PR DESCRIPTION
## What changed
- restore the sealed-state guard around `vault-init` parsing in the Vault recovery playbook
- fetch the root token separately when Vault is already unsealed so the auth-refresh path still works
- remove the duplicate `when` key introduced while applying the guard fix

## Why
The previous cleanup PR made the `Parse unseal keys and root token` task unconditional in the merged `main` flow. That breaks the valid already-unsealed recovery path because `vault_init_secret_raw` is only populated on the sealed path.

## Impact
- `ansible/playbooks/maintenance/vault-unseal.yml` now works whether Vault is sealed or already unsealed
- the playbook still unseals and rejoins followers when needed, but no longer aborts before the Kubernetes auth refresh when unseal is not required

## Validation
- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-tmp ANSIBLE_REMOTE_TEMP=/tmp/ansible-tmp ansible-playbook --syntax-check ansible/playbooks/maintenance/vault-unseal.yml`
