### PR TITLE
chore(deps): update kube-prometheus-stack chart to v87

### DIFF
--- a/argocd/apps/prod/kube-prometheus-stack.yaml
+++ b/argocd/apps/prod/kube-prometheus-stack.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
     chart: kube-prometheus-stack
-    targetRevision: 83.7.0
+    targetRevision: 87.14.0
     helm:
       values: |
         fullnameOverride: prometheus


### PR DESCRIPTION
## Summary
- update prod kube-prometheus-stack chart from 83.7.0 to 87.14.0

## Validation
- rendered with Helm v3.19.4: 81,477 lines
- server-side dry-run reached rendered resources but client-side apply of CRDs fails due kubectl last-applied annotation size on Prometheus Operator CRDs
- Prometheus Operator chart appVersion: v0.92.1

## Risk
- CRD/operator upgrade. Review before merge. ArgoCD uses ServerSideApply=true, which avoids kubectl last-applied annotation path.
