### PR TITLE
chore(deps): update Loki chart to v18

### DIFF
--- a/argocd/apps/prod/loki.yaml
+++ b/argocd/apps/prod/loki.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://grafana-community.github.io/helm-charts
     chart: loki
-    targetRevision: 13.7.2
+    targetRevision: 18.4.4
     helm:
       values: |
         fullnameOverride: loki
@@ -150,3 +150,4 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - RespectIgnoreDifferences=true


### PR DESCRIPTION
## Summary
- update prod Loki chart from 13.7.2 to 18.4.4
- add RespectIgnoreDifferences=true so existing immutable StatefulSet differences remain suppressed during sync

## Validation
- rendered with Helm v3.19.4: 838 lines
- server-side dry-run exposes existing immutable StatefulSet drift on volumeClaimTemplates if ignore differences are not respected
- live Loki StatefulSet currently has longhorn-steady volumeClaimTemplates while desired chart declares longhorn-tank; app already ignores this field

## Risk
- StatefulSet-backed logging workload. Merge only with rollout watch.
