### PR TITLE
chore(deps): update kube-prometheus-stack chart to 87.15.1

### DIFF
--- a/argocd/apps/prod/kube-prometheus-stack.yaml
+++ b/argocd/apps/prod/kube-prometheus-stack.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
     chart: kube-prometheus-stack
-    targetRevision: 87.14.0
+    targetRevision: 87.15.1
     helm:
       values: |
         fullnameOverride: prometheus


### PR DESCRIPTION
## Summary
- update prod kube-prometheus-stack chart from 87.14.0 to 87.15.1
- upstream change: kube-state-metrics subchart 7.8.0 -> 7.8.1

## Validation
- rendered with Helm v3.19.4: 81,475 lines
- YAML parsed
- prior 87.14.0 rollout is currently Synced/Healthy in prod

## Risk
- Low/medium. Small chart patch after successful v87 rollout. Still monitoring stack; merge alone and watch Argo.
