### PR TITLE
chore(deps): update netbootxyz image to 2.0.53

### DIFF
--- a/argocd/manifests/netbootxyz/overlays/prod/kustomization.yaml
+++ b/argocd/manifests/netbootxyz/overlays/prod/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../../base
 images:
   - name: lscr.io/linuxserver/netbootxyz
-    newTag: "0.7.6"
+    newTag: "2.0.53"
 patches:
   # Pin to a specific node for stable hostPort TFTP access
   - target:


### PR DESCRIPTION
## Summary
- update prod netbootxyz image from 0.7.6 to 2.0.53

## Validation
- kustomize render OK: 188 lines
- server-side dry-run OK
- live PVC bound: netbootxyz-data-pvc -> netbootxyz-data-pv
- live pod healthy before change

## Risk
- Medium. LinuxServer image is deprecated and upstream recommends official netbootxyz/docker-netbootxyz instead. This PR stays on the existing image/repo and only updates tag. Netboot app uses Recreate strategy and hostPort UDP/69 pinned to k3s-prod-worker-2; expect brief PXE/TFTP downtime during rollout.
