### PR TITLE
Migrate netbootxyz to official image

### DIFF
--- a/argocd/manifests/netbootxyz/base/deployment.yaml
+++ b/argocd/manifests/netbootxyz/base/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: netbootxyz
-          image: lscr.io/linuxserver/netbootxyz:latest
+          image: ghcr.io/netbootxyz/netbootxyz:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: PUID
@@ -32,6 +32,12 @@ spec:
               value: "America/New_York"
             - name: SUBFOLDER
               value: "/"
+            - name: WEB_APP_PORT
+              value: "3000"
+            - name: NGINX_PORT
+              value: "80"
+            - name: TFTPD_OPTS
+              value: "--tftp-single-port"
           ports:
             - name: http
               containerPort: 3000

--- a/argocd/manifests/netbootxyz/overlays/prod/kustomization.yaml
+++ b/argocd/manifests/netbootxyz/overlays/prod/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 resources:
   - ../../base
 images:
-  - name: lscr.io/linuxserver/netbootxyz
-    newTag: "0.7.6"
+  - name: ghcr.io/netbootxyz/netbootxyz
+    newTag: "latest"
 patches:
   # Pin to a specific node for stable hostPort TFTP access
   - target:


### PR DESCRIPTION
## Summary
- switch netbootxyz from deprecated LinuxServer image to official ghcr.io/netbootxyz/netbootxyz
- set explicit WEB_APP_PORT=3000 and NGINX_PORT=80
- set TFTPD_OPTS=--tftp-single-port for hostPort UDP/69 deployment

## Validation
- kustomize render OK
- server-side dry-run OK
- current prod netbootxyz rollback is Synced/Healthy on 0.7.6

## Risk
- Medium. Recreate rollout, PVC-backed /config and /assets, hostPort UDP/69 pinned to k3s-prod-worker-2. Expect brief PXE/TFTP downtime. Merge only with rollout watch.
