### PR TITLE
Prepare netbootxyz official image migration

### DIFF
--- a/argocd/manifests/netbootxyz/base/deployment.yaml
+++ b/argocd/manifests/netbootxyz/base/deployment.yaml
@@ -24,14 +24,8 @@ spec:
           image: ghcr.io/netbootxyz/netbootxyz:latest
           imagePullPolicy: IfNotPresent
           env:
-            - name: PUID
-              value: "1000"
-            - name: PGID
-              value: "1000"
             - name: TZ
               value: "America/New_York"
-            - name: SUBFOLDER
-              value: "/"
             - name: WEB_APP_PORT
               value: "3000"
             - name: NGINX_PORT

--- a/argocd/manifests/netbootxyz/base/deployment.yaml
+++ b/argocd/manifests/netbootxyz/base/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: netbootxyz
   namespace: netbootxyz
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     app: netbootxyz
     app.kubernetes.io/name: netbootxyz

--- a/argocd/manifests/netbootxyz/base/job-migrate-config.yaml
+++ b/argocd/manifests/netbootxyz/base/job-migrate-config.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: netbootxyz-migrate-config
+  namespace: netbootxyz
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      nodeSelector:
+        kubernetes.io/hostname: k3s-prod-worker-2
+      containers:
+        - name: migrate-config
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              rm -f /config/nginx/nginx.conf
+              rm -rf /config/nginx/site-confs
+          volumeMounts:
+            - name: netbootxyz-data
+              mountPath: /config
+              subPath: config
+      volumes:
+        - name: netbootxyz-data
+          persistentVolumeClaim:
+            claimName: netbootxyz-data-pvc

--- a/argocd/manifests/netbootxyz/base/job-migrate-config.yaml
+++ b/argocd/manifests/netbootxyz/base/job-migrate-config.yaml
@@ -4,8 +4,9 @@ metadata:
   name: netbootxyz-migrate-config
   namespace: netbootxyz
   annotations:
-    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   template:
     spec:

--- a/argocd/manifests/netbootxyz/base/kustomization.yaml
+++ b/argocd/manifests/netbootxyz/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - pvc.yaml
+  - job-migrate-config.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml

--- a/argocd/manifests/netbootxyz/overlays/prod/kustomization.yaml
+++ b/argocd/manifests/netbootxyz/overlays/prod/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../../base
 images:
   - name: ghcr.io/netbootxyz/netbootxyz
-    newTag: "latest"
+    newTag: "0.7.6-nbxyz23"
 patches:
   # Pin to a specific node for stable hostPort TFTP access
   - target:


### PR DESCRIPTION
## Summary
- pin official netbootxyz image to `0.7.6-nbxyz23`
- remove LinuxServer-only env vars from deployment
- add PreSync migration job to remove persisted LinuxServer nginx config before rollout

## Why
Existing prod PVC can contain `/config/nginx/nginx.conf` and `site-confs` generated by LinuxServer with `user abc;`. Official image only has `nbxyz` and will not replace existing nginx config, so port 80 asset service can fail while port 3000 probes still pass.

## Validation
- `kubectl kustomize argocd/manifests/netbootxyz/overlays/prod`
- `KUBECONFIG=/home/pierce/.kube/config kubectl --context k3s-prod apply --server-side --dry-run=server -f /tmp/netbootxyz-rendered.yaml`

## Rollout risk
Medium. Deployment uses `Recreate` and TFTP uses hostPort UDP/69 on `k3s-prod-worker-2`. Watch rollout plus port 80 asset service after sync.